### PR TITLE
Refactor transaction email receipt handling

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/TransactionDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/TransactionDomainEventHandlerTests.cs
@@ -42,53 +42,18 @@ namespace TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers
     
     public class TransactionDomainEventHandlerTests
     {
-        private Mock<IAggregateRepository<SettlementAggregate, DomainEvent>> SettlementAggregateRepository;
-        private Mock<IAggregateRepository<TransactionAggregate, DomainEvent>> TransactionAggregateRepository;
-
-        private Mock<IFeeCalculationManager> FeeCalculationManager;
-
-        private Mock<IEstateClient> EstateClient;
-
-        private Mock<ISecurityServiceClient> SecurityServiceClient;
-
-        private Mock<ITransactionReceiptBuilder> TransactionReceiptBuilder;
-
-        private Mock<IMessagingServiceClient> MessagingServiceClient;
-
-        private Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>> FloatActivityAggregateRepository;
-
-        private Mock<IMemoryCacheWrapper> MemoryCache;
-
         private TransactionDomainEventHandler TransactionDomainEventHandler;
         private Mock<IMediator> Mediator;
 
         public TransactionDomainEventHandlerTests()
         {
-            this.SettlementAggregateRepository = new Mock<IAggregateRepository<SettlementAggregate, DomainEvent>>();
-            this.TransactionAggregateRepository = new Mock<IAggregateRepository<TransactionAggregate, DomainEvent>>();
-            this.FloatActivityAggregateRepository = new Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>>();
-            this.FeeCalculationManager = new Mock<IFeeCalculationManager>();
-            this.EstateClient = new Mock<IEstateClient>();
-            this.SecurityServiceClient = new Mock<ISecurityServiceClient>();
-            this.TransactionReceiptBuilder = new Mock<ITransactionReceiptBuilder>();
-            this.MessagingServiceClient = new Mock<IMessagingServiceClient>();
-            this.MemoryCache = new Mock<IMemoryCacheWrapper>();
             this.Mediator= new Mock<IMediator>();
 
             IConfigurationRoot configurationRoot = new ConfigurationBuilder().AddInMemoryCollection(TestData.DefaultAppSettings).Build();
             ConfigurationReader.Initialise(configurationRoot);
             Logger.Initialise(NullLogger.Instance);
 
-            this.TransactionDomainEventHandler = new TransactionDomainEventHandler(this.TransactionAggregateRepository.Object,
-                                                                                   this.FeeCalculationManager.Object,
-                                                                                   this.EstateClient.Object,
-                                                                                   this.SecurityServiceClient.Object,
-                                                                                   this.TransactionReceiptBuilder.Object,
-                                                                                   this.MessagingServiceClient.Object,
-                                                                                   this.SettlementAggregateRepository.Object,
-                                                                                   this.FloatActivityAggregateRepository.Object,
-                                                                                   this.MemoryCache.Object,
-                                                                                   this.Mediator.Object);
+            this.TransactionDomainEventHandler = new TransactionDomainEventHandler(this.Mediator.Object);
 
             this.Mediator.Setup(s => s.Send(It.IsAny<IRequest<Result>>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
         }

--- a/TransactionProcessor.BusinessLogic.Tests/Mediator/DummyTransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Mediator/DummyTransactionDomainService.cs
@@ -45,6 +45,12 @@ public class DummyTransactionDomainService : ITransactionDomainService
     public async Task<Result> AddSettledMerchantFee(TransactionCommands.AddSettledMerchantFeeCommand command,
                                                     CancellationToken cancellationToken) =>
         Result.Success();
+
+    public async Task<Result> SendCustomerEmailReceipt(TransactionCommands.SendCustomerEmailReceiptCommand command,
+                                                       CancellationToken cancellationToken) => Result.Success();
+
+    public async Task<Result> ResendCustomerEmailReceipt(TransactionCommands.ResendCustomerEmailReceiptCommand command,
+                                                         CancellationToken cancellationToken) => Result.Success();
 }
 
 public class DummyMerchantBalanceStateRepository : IProjectionStateRepository<MerchantBalanceState>

--- a/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
@@ -54,8 +54,8 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
         private readonly Mock<IAggregateRepository<FloatAggregate, DomainEvent>> FloatAggregateRepository;
         private readonly Mock<IMemoryCacheWrapper> MemoryCacheWrapper;
         private readonly Mock<IFeeCalculationManager> FeeCalculationManager;
-        private Mock<ITransactionReceiptBuilder> TransactionReceiptBuilder;
-        private Mock<IMessagingServiceClient> MessagingServiceClient;
+        private readonly Mock<ITransactionReceiptBuilder> TransactionReceiptBuilder;
+        private readonly Mock<IMessagingServiceClient> MessagingServiceClient;
         #endregion
 
         #region Constructors
@@ -760,12 +760,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
         {
             this.SecurityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse()));
             this.TransactionAggregateRepository.Setup(t => t.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
-            //this.EstateClient.Setup(e => e.GetMerchant(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetMerchantResponseWithOperator1));
-            //this.EstateClient.Setup(e => e.GetEstate(It.IsAny<String>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            //    .ReturnsAsync(TestData.GetEstateResponseWithOperator1);
-
-            //this.TransactionReceiptBuilder.Setup(r => r.GetEmailReceiptMessage(It.IsAny<Models.Transaction>(), It.IsAny<MerchantResponse>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync("EmailMessage");
-            //this.MessagingServiceClient.Setup(m => m.SendEmail(It.IsAny<String>(), It.IsAny<SendEmailRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+            
             TransactionCommands.SendCustomerEmailReceiptCommand command = new(TestData.EstateId, TestData.TransactionId, Guid.NewGuid(), TestData.CustomerEmailAddress);
             var result = await this.TransactionDomainService.SendCustomerEmailReceipt(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
@@ -789,7 +784,6 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
             this.SecurityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse()));
             this.TransactionAggregateRepository.Setup(t => t.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
-            //this.MessagingServiceClient.Setup(m => m.SendEmail(It.IsAny<String>(), It.IsAny<SendEmailRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
             TransactionCommands.ResendCustomerEmailReceiptCommand command = new(TestData.EstateId, TestData.TransactionId);
             var result = await this.TransactionDomainService.ResendCustomerEmailReceipt(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();

--- a/TransactionProcessor.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/TransactionProcessor.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -10,21 +10,13 @@ namespace TransactionProcessor.BusinessLogic.RequestHandlers
     using Services;
     using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <seealso cref="MediatR.IRequestHandler{TransactionProcessor.BusinessLogic.Requests.ProcessLogonTransactionRequest, TransactionProcessor.Models.ProcessLogonTransactionResponse}" />
-    /// <seealso cref="MediatR.IRequestHandler{TransactionProcessor.BusinessLogic.Requests.ProcessSaleTransactionRequest, TransactionProcessor.Models.ProcessSaleTransactionResponse}" />
-    /// <seealso cref="MediatR.IRequestHandler{TransactionProcessor.BusinessLogic.Requests.ProcessReconciliationRequest, TransactionProcessor.BusinessLogic.Requests.ProcessReconciliationResponse}" />
-    /// <seealso cref="MediatR.IRequestHandler{ProcessLogonTransactionRequest, ProcessLogonTransactionResponse}" />
-    /// <seealso cref="" />
     public class TransactionRequestHandler : IRequestHandler<TransactionCommands.ProcessLogonTransactionCommand, Result<ProcessLogonTransactionResponse>>,
                                              IRequestHandler<TransactionCommands.ProcessSaleTransactionCommand, Result<ProcessSaleTransactionResponse>>,
                                              IRequestHandler<TransactionCommands.ProcessReconciliationCommand, Result<ProcessReconciliationTransactionResponse>>,
                                              IRequestHandler<TransactionCommands.ResendTransactionReceiptCommand,Result>,
                                              IRequestHandler<TransactionCommands.CalculateFeesForTransactionCommand, Result>,
-                                             IRequestHandler<TransactionCommands.AddSettledMerchantFeeCommand, Result>
-    {
+                                             IRequestHandler<TransactionCommands.AddSettledMerchantFeeCommand, Result>,
+                                             IRequestHandler<TransactionCommands.SendCustomerEmailReceiptCommand, Result> {
         #region Fields
 
         /// <summary>
@@ -82,6 +74,11 @@ namespace TransactionProcessor.BusinessLogic.RequestHandlers
         public async Task<Result> Handle(TransactionCommands.AddSettledMerchantFeeCommand command,
                                          CancellationToken cancellationToken) {
             return await this.TransactionDomainService.AddSettledMerchantFee(command, cancellationToken);
+        }
+
+        public async Task<Result> Handle(TransactionCommands.SendCustomerEmailReceiptCommand command,
+                                         CancellationToken cancellationToken) {
+            return await this.TransactionDomainService.SendCustomerEmailReceipt(command, cancellationToken);
         }
     }
 }

--- a/TransactionProcessor.BusinessLogic/Requests/TransactionCommands.cs
+++ b/TransactionProcessor.BusinessLogic/Requests/TransactionCommands.cs
@@ -47,4 +47,7 @@ public record TransactionCommands {
     public record CalculateFeesForTransactionCommand(Guid TransactionId, DateTime CompletedDateTime, Guid EstateId, Guid MerchantId) : IRequest<Result>;
 
     public record AddSettledMerchantFeeCommand(Guid TransactionId, Decimal CalculatedValue, DateTime FeeCalculatedDateTime, CalculationType FeeCalculationType, Guid FeeId, Decimal FeeValue, DateTime SettledDateTime, Guid SettlementId) : IRequest<Result>;
+
+    public record SendCustomerEmailReceiptCommand(Guid EstateId, Guid TransactionId, Guid EventId, String CustomerEmailAddress) : IRequest<Result>;
+    public record ResendCustomerEmailReceiptCommand(Guid EstateId, Guid TransactionId) : IRequest<Result>;
 }

--- a/TransactionProcessor.BusinessLogic/Services/ITransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/ITransactionDomainService.cs
@@ -32,5 +32,10 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         Task<Result> AddSettledMerchantFee(TransactionCommands.AddSettledMerchantFeeCommand command,
                                            CancellationToken cancellationToken);
+
+        Task<Result> SendCustomerEmailReceipt(TransactionCommands.SendCustomerEmailReceiptCommand command,
+                                              CancellationToken cancellationToken);
+        Task<Result> ResendCustomerEmailReceipt(TransactionCommands.ResendCustomerEmailReceiptCommand command,
+                                              CancellationToken cancellationToken);
     }
 }

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="EstateManagement.Client" Version="2024.8.2-build127" />
     <PackageReference Include="EstateManagement.Database" Version="2024.8.2-build127" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
-    <PackageReference Include="MessagingService.Client" Version="2024.8.2-build65" />
+    <PackageReference Include="MessagingService.Client" Version="2024.11.2-build67" />
     <PackageReference Include="SecurityService.Client" Version="2024.88.2-build73" />
     <PackageReference Include="Shared.DomainDrivenDesign" Version="2024.11.4" />
     <PackageReference Include="Shared.EventStore" Version="2024.11.4" />

--- a/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
+++ b/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2024.8.2-build65" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2024.11.2-build67" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.TransactionAgrgegate/TransactionAggregate.cs
+++ b/TransactionProcessor.TransactionAgrgegate/TransactionAggregate.cs
@@ -532,6 +532,7 @@
         {
             aggregate.CustomerEmailAddress = domainEvent.CustomerEmailAddress;
             aggregate.CustomerEmailReceiptHasBeenRequested = true;
+            aggregate.ReceiptMessageId = domainEvent.EventId;
         }
 
         public static void PlayEvent(this TransactionAggregate aggregate, CustomerEmailReceiptResendRequestedEvent domainEvent)
@@ -694,6 +695,7 @@
         public String AuthorisationCode { get; internal set; }
 
         public Guid ContractId { get; internal set; }
+        public Guid ReceiptMessageId { get; internal set; }
 
         public Boolean CustomerEmailReceiptHasBeenRequested { get; internal set; }
 

--- a/TransactionProcessor/Common/ClientMessageLoggingBehavior.cs
+++ b/TransactionProcessor/Common/ClientMessageLoggingBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Shared.Middleware;
+﻿using System.Diagnostics.CodeAnalysis;
+using Shared.Middleware;
 
 namespace TransactionProcessor.Common;
 
@@ -7,6 +8,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
 
+[ExcludeFromCodeCoverage]
 internal sealed class ClientMessageLoggingBehavior :
     IEndpointBehavior{
     #region Fields

--- a/TransactionProcessor/Common/ServiceEndpointExtensions.cs
+++ b/TransactionProcessor/Common/ServiceEndpointExtensions.cs
@@ -3,8 +3,10 @@
 namespace TransactionProcessor.Common;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.ServiceModel.Description;
 
+[ExcludeFromCodeCoverage]
 public static class ServiceEndpointExtensions{
     #region Methods
 


### PR DESCRIPTION
- Simplified `TransactionDomainEventHandlerTests` by removing unnecessary mock dependencies and retaining only `Mediator`.
- Added `SendCustomerEmailReceipt` and `ResendCustomerEmailReceipt` methods to `DummyTransactionDomainService`.
- Updated `TransactionDomainServiceTests` with new dependencies and test methods for email receipt functionality.
- Refactored `TransactionDomainEventHandler` to rely solely on `IMediator` for command handling.
- Enhanced `TransactionRequestHandler` to include a handler for `SendCustomerEmailReceiptCommand`.
- Extended `TransactionCommands` with new command records for email receipt operations.
- Updated `ITransactionDomainService` interface to include new email receipt methods.
- Modified `TransactionDomainService` to implement email receipt methods using the mediator.
- Added `ReceiptMessageId` property to `TransactionAggregate` for email receipt event handling.
- Updated project references for `MessagingService.Client` and `MessagingService.IntegrationTesting.Helpers`.
- Added `ExcludeFromCodeCoverage` attributes to `ClientMessageLoggingBehavior` and `ServiceEndpointExtensions`.