### PR TITLE
Refactor estate client to use IIntermediateEstateClient

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
@@ -23,12 +23,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
     using Shared.Logger;
     using Shouldly;
     using Testing;
+    using TransactionProcessor.BusinessLogic.Common;
     using TransactionProcessor.BusinessLogic.Services;
     using Xunit;
 
     public class FloatDomainServiceTests
     {
-        private readonly Mock<IEstateClient> EstateClient;
+        private readonly Mock<IIntermediateEstateClient> EstateClient;
         private readonly Mock<ISecurityServiceClient> SecurityServiceClient;
         private readonly Mock<IAggregateRepository<FloatAggregate, DomainEvent>> FloatAggregateRepository;
         private readonly Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>> FloatActivityAggregateRepository;
@@ -43,7 +44,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            this.EstateClient = new Mock<IEstateClient>();
+            this.EstateClient = new Mock<IIntermediateEstateClient>();
             this.SecurityServiceClient = new Mock<ISecurityServiceClient>();
             this.FloatAggregateRepository = new Mock<IAggregateRepository<FloatAggregate, DomainEvent>>();
             this.FloatActivityAggregateRepository = new Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>>();

--- a/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
@@ -21,6 +21,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
     using Shouldly;
     using Testing;
     using TransactionAggregate;
+    using TransactionProcessor.BusinessLogic.Common;
     using Xunit;
 
     public class SettlementDomainServiceTests
@@ -31,7 +32,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
         private Mock<ISecurityServiceClient> securityServiceClient;
 
-        private Mock<IEstateClient> estateClient;
+        private Mock<IIntermediateEstateClient> estateClient;
 
         private SettlementDomainService settlementDomainService;
 
@@ -41,7 +42,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
             this.settlementAggregateRepository =
                 new Mock<IAggregateRepository<SettlementAggregate, DomainEvent>>();
             this.securityServiceClient = new Mock<ISecurityServiceClient>();
-            this.estateClient = new Mock<IEstateClient>();
+            this.estateClient = new Mock<IIntermediateEstateClient>();
             
             this.settlementDomainService =
                 new SettlementDomainService(this.transactionAggregateRepository.Object, settlementAggregateRepository.Object,

--- a/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
@@ -37,7 +37,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
     public class TransactionDomainServiceTests{
         #region Fields
 
-        private readonly Mock<IEstateClient> EstateClient;
+        private readonly Mock<IIntermediateEstateClient> EstateClient;
 
         private readonly Mock<IOperatorProxy> OperatorProxy;
 
@@ -67,7 +67,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
             Logger.Initialise(NullLogger.Instance);
 
             this.TransactionAggregateRepository = new Mock<IAggregateRepository<TransactionAggregate, DomainEvent>>();
-            this.EstateClient = new Mock<IEstateClient>();
+            this.EstateClient = new Mock<IIntermediateEstateClient>();
             this.SecurityServiceClient = new Mock<ISecurityServiceClient>();
             this.OperatorProxy = new Mock<IOperatorProxy>();
             this.ReconciliationAggregateRepository = new Mock<IAggregateRepository<ReconciliationAggregate, DomainEvent>>();

--- a/TransactionProcessor.BusinessLogic.Tests/Services/TransactionValidationServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/TransactionValidationServiceTests.cs
@@ -21,6 +21,7 @@ using Shared.General;
 using Shared.Logger;
 using Shouldly;
 using Testing;
+using TransactionProcessor.BusinessLogic.Common;
 using Xunit;
 
 public class TransactionValidationServiceTests {
@@ -28,7 +29,7 @@ public class TransactionValidationServiceTests {
     private readonly Mock<ISecurityServiceClient> SecurityServiceClient;
 
     private readonly Mock<IProjectionStateRepository<MerchantBalanceState>> StateRepository;
-    private readonly Mock<IEstateClient> EstateClient;
+    private readonly Mock<IIntermediateEstateClient> EstateClient;
     private readonly Mock<IEventStoreContext> EventStoreContext;
     public TransactionValidationServiceTests() {
         IConfigurationRoot configurationRoot = new ConfigurationBuilder().AddInMemoryCollection(TestData.DefaultAppSettings).Build();
@@ -36,7 +37,7 @@ public class TransactionValidationServiceTests {
 
         Logger.Initialise(NullLogger.Instance);
 
-        this.EstateClient = new Mock<IEstateClient>();
+        this.EstateClient = new Mock<IIntermediateEstateClient>();
         this.SecurityServiceClient = new Mock<ISecurityServiceClient>();
         this.StateRepository = new Mock<IProjectionStateRepository<MerchantBalanceState>>();
         this.EventStoreContext = new Mock<IEventStoreContext>();

--- a/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using SimpleResults;
+using TransactionProcessor.BusinessLogic.Common;
 
 namespace TransactionProcessor.BusinessLogic.Tests.Services
 {
@@ -37,7 +38,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
@@ -74,7 +75,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
@@ -111,7 +112,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
@@ -149,7 +150,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
@@ -186,7 +187,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
@@ -226,7 +227,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -264,7 +265,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -305,7 +306,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            Mock<IEstateClient> estateClient = new Mock<IEstateClient>();
+            Mock<IIntermediateEstateClient> estateClient = new Mock<IIntermediateEstateClient>();
             Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
             Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
             voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))

--- a/TransactionProcessor.BusinessLogic/Common/IIntermediateEstateClient.cs
+++ b/TransactionProcessor.BusinessLogic/Common/IIntermediateEstateClient.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EstateManagement.Client;
+using EstateManagement.DataTransferObjects.Requests.Merchant;
+using EstateManagement.DataTransferObjects.Responses.Contract;
+using EstateManagement.DataTransferObjects.Responses.Estate;
+using EstateManagement.DataTransferObjects.Responses.Merchant;
+using SimpleResults;
+
+namespace TransactionProcessor.BusinessLogic.Common
+{
+    public interface IIntermediateEstateClient
+    {
+        Task<Result<EstateResponse>> GetEstate(
+            string accessToken,
+            Guid estateId,
+            CancellationToken cancellationToken);
+
+        Task<Result<MerchantResponse>> GetMerchant(
+            string accessToken,
+            Guid estateId,
+            Guid merchantId,
+            CancellationToken cancellationToken);
+
+        Task<Result<List<ContractProductTransactionFee>>> GetTransactionFeesForProduct(
+            string accessToken,
+            Guid estateId,
+            Guid merchantId,
+            Guid contractId,
+            Guid productId,
+            CancellationToken cancellationToken);
+
+        Task<Result<ContractResponse>> GetContract(
+            string accessToken,
+            Guid estateId,
+            Guid contractId,
+            CancellationToken cancellationToken);
+
+        Task<Result> AddDeviceToMerchant(
+            string accessToken,
+            Guid estateId,
+            Guid merchantId,
+            AddMerchantDeviceRequest request,
+            CancellationToken cancellationToken);
+
+        Task<Result<List<ContractResponse>>> GetMerchantContracts(
+            string accessToken,
+            Guid estateId,
+            Guid merchantId,
+            CancellationToken cancellationToken);
+
+        public IEstateClient EstateClient { get; }
+    }
+
+    public class IntermediateEstateClient : IIntermediateEstateClient {
+        
+        public IntermediateEstateClient(IEstateClient estateClient) {
+            this.EstateClient = estateClient;
+        }
+
+        public async Task<Result<EstateResponse>> GetEstate(String accessToken,
+                                                            Guid estateId,
+                                                            CancellationToken cancellationToken) {
+            return await this.EstateClient.GetEstate(accessToken, estateId, cancellationToken);
+        }
+
+        public async Task<Result<MerchantResponse>> GetMerchant(String accessToken,
+                                                                Guid estateId,
+                                                                Guid merchantId,
+                                                                CancellationToken cancellationToken) {
+            return await this.EstateClient.GetMerchant(accessToken, estateId, merchantId, cancellationToken);
+        }
+
+        public async Task<Result<List<ContractProductTransactionFee>>> GetTransactionFeesForProduct(String accessToken,
+                                                                                                    Guid estateId,
+                                                                                                    Guid merchantId,
+                                                                                                    Guid contractId,
+                                                                                                    Guid productId,
+                                                                                                    CancellationToken cancellationToken) {
+            return await this.EstateClient.GetTransactionFeesForProduct(accessToken, estateId, merchantId, contractId, productId, cancellationToken);
+        }
+
+        public async Task<Result<ContractResponse>> GetContract(String accessToken,
+                                                                Guid estateId,
+                                                                Guid contractId,
+                                                                CancellationToken cancellationToken) {
+            return await this.EstateClient.GetContract(accessToken, estateId, contractId, cancellationToken);
+        }
+
+        public async Task<Result> AddDeviceToMerchant(String accessToken,
+                                                      Guid estateId,
+                                                      Guid merchantId,
+                                                      AddMerchantDeviceRequest request,
+                                                      CancellationToken cancellationToken) {
+            return await this.EstateClient.AddDeviceToMerchant(accessToken, estateId, merchantId, request, cancellationToken);
+        }
+
+        public async Task<Result<List<ContractResponse>>> GetMerchantContracts(String accessToken,
+                                                                               Guid estateId,
+                                                                               Guid merchantId,
+                                                                               CancellationToken cancellationToken) {
+            return await this.EstateClient.GetMerchantContracts(accessToken, estateId, merchantId, cancellationToken);
+        }
+
+        public IEstateClient EstateClient { get; }
+    }
+}

--- a/TransactionProcessor.BusinessLogic/Services/IFloatDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/IFloatDomainService.cs
@@ -48,13 +48,13 @@ namespace TransactionProcessor.BusinessLogic.Services
         private readonly IAggregateRepository<FloatActivityAggregate, DomainEvent> FloatActivityAggregateRepository;
         private readonly IAggregateRepository<TransactionAggregate.TransactionAggregate, DomainEvent> TransactionAggregateRepository;
 
-        private readonly IEstateClient EstateClient;
+        private readonly IIntermediateEstateClient EstateClient;
         private readonly ISecurityServiceClient SecurityServiceClient;
 
         public FloatDomainService(IAggregateRepository<FloatAggregate, DomainEvent> floatAggregateRepository,
                                   IAggregateRepository<FloatActivityAggregate, DomainEvent> floatActivityAggregateRepository,
                                   IAggregateRepository<TransactionAggregate.TransactionAggregate,DomainEvent> transactionAggregateRepository,
-                                  IEstateClient estateClient,
+                                  IIntermediateEstateClient estateClient,
                                   ISecurityServiceClient securityServiceClient)
         {
             this.FloatAggregateRepository = floatAggregateRepository;

--- a/TransactionProcessor.BusinessLogic/Services/SettlementDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/SettlementDomainService.cs
@@ -32,7 +32,7 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         private readonly ISecurityServiceClient SecurityServiceClient;
 
-        private readonly IEstateClient EstateClient;
+        private readonly IIntermediateEstateClient EstateClient;
 
         private async Task<Result> ApplySettlementUpdates(Func<SettlementAggregate, Task<Result>> action,
                                                      Guid settlementId,
@@ -233,7 +233,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         public SettlementDomainService(IAggregateRepository<TransactionAggregate, DomainEvent> transactionAggregateRepository,
                                        IAggregateRepository<SettlementAggregate, DomainEvent> settlementAggregateRepository,
                                        ISecurityServiceClient securityServiceClient,
-                                       IEstateClient estateClient)
+                                       IIntermediateEstateClient estateClient)
         {
             this.TransactionAggregateRepository = transactionAggregateRepository;
             this.SettlementAggregateRepository = settlementAggregateRepository;

--- a/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
@@ -45,7 +45,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
         /// <summary>
         /// The estate client
         /// </summary>
-        private readonly IEstateClient EstateClient;
+        private readonly IIntermediateEstateClient EstateClient;
 
         /// <summary>
         /// The operator proxy resolver
@@ -76,7 +76,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
         #region Constructors
 
         public TransactionDomainService(IAggregateRepository<TransactionAggregate, DomainEvent> transactionAggregateRepository,
-                                        IEstateClient estateClient,
+                                        IIntermediateEstateClient estateClient,
                                         Func<String, IOperatorProxy> operatorProxyResolver,
                                         IAggregateRepository<ReconciliationAggregate, DomainEvent> reconciliationAggregateRepository,
                                         ITransactionValidationService transactionValidationService,

--- a/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
@@ -33,7 +33,7 @@ public class TransactionValidationService : ITransactionValidationService{
     /// <summary>
     /// The estate client
     /// </summary>
-    private readonly IEstateClient EstateClient;
+    private readonly IIntermediateEstateClient EstateClient;
 
     private readonly ProjectionEngine.Repository.IProjectionStateRepository<MerchantBalanceState> MerchantBalanceStateRepository;
 
@@ -49,7 +49,7 @@ public class TransactionValidationService : ITransactionValidationService{
 
     #endregion
 
-    public TransactionValidationService(IEstateClient estateClient,
+    public TransactionValidationService(IIntermediateEstateClient estateClient,
                                         ISecurityServiceClient securityServiceClient,
                                         ProjectionEngine.Repository.IProjectionStateRepository<MerchantBalanceState> merchantBalanceStateRepository,
                                         IEventStoreContext eventStoreContext)

--- a/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
@@ -42,7 +42,7 @@ public class VoucherDomainService : IVoucherDomainService
     /// <summary>
     /// The estate client
     /// </summary>
-    private readonly IEstateClient EstateClient;
+    private readonly IIntermediateEstateClient EstateClient;
 
     /// <summary>
     /// The database context factory
@@ -62,7 +62,7 @@ public class VoucherDomainService : IVoucherDomainService
     /// <param name="dbContextFactory">The database context factory.</param>
     public VoucherDomainService(IAggregateRepository<VoucherAggregate, DomainEvent> voucherAggregateRepository,
                                 ISecurityServiceClient securityServiceClient,
-                                IEstateClient estateClient,
+                                IIntermediateEstateClient estateClient,
                                 Shared.EntityFramework.IDbContextFactory<EstateManagementGenericContext> dbContextFactory)
     {
         this.VoucherAggregateRepository = voucherAggregateRepository;

--- a/TransactionProcessor.IntegrationTests/Common/DockerHelper.cs
+++ b/TransactionProcessor.IntegrationTests/Common/DockerHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace TransactionProcessor.IntegrationTests.Common
+﻿using TransactionProcessor.BusinessLogic.Common;
+
+namespace TransactionProcessor.IntegrationTests.Common
 {
     using System;
     using System.Collections.Generic;
@@ -29,7 +31,7 @@
         /// <summary>
         /// The estate client
         /// </summary>
-        public IEstateClient EstateClient;
+        public IIntermediateEstateClient EstateClient;
 
         public HttpClient TestHostHttpClient;
 
@@ -114,7 +116,7 @@
                                                                                               }
                                               };
             HttpClient httpClient = new HttpClient(clientHandler);
-            this.EstateClient = new EstateClient(EstateManagementBaseAddressResolver, httpClient,2);
+            this.EstateClient = new IntermediateEstateClient(new EstateClient(EstateManagementBaseAddressResolver, httpClient,2));
             this.SecurityServiceClient = new SecurityServiceClient(SecurityServiceBaseAddressResolver, httpClient);
             this.TransactionProcessorClient = new TransactionProcessorClient(TransactionProcessorBaseAddressResolver, httpClient);
             this.TestHostHttpClient= new HttpClient(clientHandler);

--- a/TransactionProcessor.IntegrationTests/Shared/SharedSteps.cs
+++ b/TransactionProcessor.IntegrationTests/Shared/SharedSteps.cs
@@ -50,7 +50,7 @@ namespace TransactionProcessor.IntegrationTests.Shared
             this.ScenarioContext = scenarioContext;
             this.TestingContext = testingContext;
             this.SecurityServiceSteps = new SecurityServiceSteps(testingContext.DockerHelper.SecurityServiceClient);
-            this.EstateManagementSteps = new EstateManagementSteps(testingContext.DockerHelper.EstateClient, testingContext.DockerHelper.TestHostHttpClient);
+            this.EstateManagementSteps = new EstateManagementSteps(testingContext.DockerHelper.EstateClient.EstateClient, testingContext.DockerHelper.TestHostHttpClient);
             this.TransactionProcessorSteps = new TransactionProcessorSteps(testingContext.DockerHelper.TransactionProcessorClient, testingContext.DockerHelper.TestHostHttpClient,
                 testingContext.DockerHelper.ProjectionManagementClient);
         }

--- a/TransactionProcessor/Bootstrapper/ClientRegistry.cs
+++ b/TransactionProcessor/Bootstrapper/ClientRegistry.cs
@@ -9,7 +9,8 @@
     using Microsoft.Extensions.DependencyInjection;
     using SecurityService.Client;
     using Shared.General;
-    
+    using TransactionProcessor.BusinessLogic.Common;
+
     /// <summary>
     /// 
     /// </summary>
@@ -48,6 +49,7 @@
             this.AddSingleton(httpClient);
 
             this.AddSingleton<IEstateClient>(new EstateClient(resolver1(), httpClient, 2));
+            this.AddSingleton<IIntermediateEstateClient, IntermediateEstateClient>();
         }
 
         #endregion


### PR DESCRIPTION
Replaced instances of IEstateClient with IIntermediateEstateClient across multiple test files and service implementations. This change affects test classes such as FloatDomainServiceTests, SettlementDomainServiceTests, TransactionDomainServiceTests, and TransactionValidationServiceTests, as well as service classes like FloatDomainService, SettlementDomainService, and VoucherDomainService. The new IIntermediateEstateClient interface wraps the existing IEstateClient, enhancing the architecture by introducing an intermediate layer for estate client operations, improving separation of concerns and facilitating easier testing.