### PR TITLE
Update package versions and refine configurations

### DIFF
--- a/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
+++ b/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.EventStore" Version="2025.1.2" />
+		<PackageReference Include="Shared.EventStore" Version="2025.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="CallbackHandler.DataTransferObjects" Version="2024.11.1" />
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
     <PackageReference Include="MessagingService.Client" Version="2025.1.4" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2025.1.2" />
-    <PackageReference Include="Shared.EventStore" Version="2025.1.2" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2025.2.1" />
+    <PackageReference Include="Shared.EventStore" Version="2025.2.1" />
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />

--- a/TransactionProcessor.Client/TransactionProcessor.Client.csproj
+++ b/TransactionProcessor.Client/TransactionProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
-    <PackageReference Include="Shared.Results" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
+    <PackageReference Include="Shared.Results" Version="2025.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Database/TransactionProcessor.Database.csproj
+++ b/TransactionProcessor.Database/TransactionProcessor.Database.csproj
@@ -19,9 +19,9 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
 		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-		<PackageReference Include="Shared" Version="2025.1.1" />
+		<PackageReference Include="Shared" Version="2025.2.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.1.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
+++ b/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.1.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.2.1" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
     <PackageReference Include="Reqnroll" Version="1.0.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.1.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
+++ b/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
     <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.1.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.1.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.2.1" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="1.0.1" />
 	  <PackageReference Include="NUnit" Version="4.1.0" />

--- a/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
+++ b/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="FileProcessor.File.DomainEvents" Version="2025.1.1" />
     <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2025.1.1" />
     
-    <PackageReference Include="Shared" Version="2025.1.2" />
-    <PackageReference Include="Shared.EventStore" Version="2025.1.2" />
+    <PackageReference Include="Shared" Version="2025.2.1" />
+    <PackageReference Include="Shared.EventStore" Version="2025.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
+++ b/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
@@ -13,8 +13,8 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
-		<PackageReference Include="Shared" Version="2025.1.1" />
-		<PackageReference Include="Shared.EventStore" Version="2025.1.1" />
+		<PackageReference Include="Shared" Version="2025.2.1" />
+		<PackageReference Include="Shared.EventStore" Version="2025.2.1" />
 
 	</ItemGroup>
 

--- a/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
+++ b/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
   </ItemGroup>
 

--- a/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
+++ b/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+    <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/TransactionProcessor/TransactionProcessor.csproj
+++ b/TransactionProcessor/TransactionProcessor.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
+	  <PackageReference Include="ClientProxyBase" Version="2025.2.1" />
 	  <PackageReference Include="Lamar" Version="13.0.3" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="13.0.3" />
 	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
@@ -37,8 +37,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.8" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
-    <PackageReference Include="Shared" Version="2025.1.2" />
-    <PackageReference Include="Shared.EventStore" Version="2025.1.2" />
+    <PackageReference Include="Shared" Version="2025.2.1" />
+    <PackageReference Include="Shared.EventStore" Version="2025.2.1" />
       <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	  <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/TransactionProcessor/appsettings.json
+++ b/TransactionProcessor/appsettings.json
@@ -49,9 +49,6 @@
       "SettlementScheduleChangedEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
       ],
-      "CallbackReceivedEnrichedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.MerchantDomainEventHandler,TransactionProcessor.BusinessLogic"
-      ],
       "ContractAddedToMerchantEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
@@ -114,29 +111,21 @@
 
       // Transaction Event Handler
       "TransactionHasBeenCompletedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic",
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "CustomerEmailReceiptRequestedEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "SettledMerchantFeeAddedToTransactionEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic",
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
       ],
       "MerchantFeeSettledEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic",
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
-      ],
-      "MerchantFeePendingSettlementAddedToTransactionEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
-      ],
+      ],      
       "TransactionCostInformationRecordedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler, TransactionProcessor.BusinessLogic",
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "FloatCreditPurchasedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler, TransactionProcessor.BusinessLogic",
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
       ],
       "FloatCreatedForContractProductEvent": [
@@ -187,17 +176,6 @@
       "ReconciliationHasCompletedEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
-      //"VoucherGeneratedEvent": [
-      //  "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
-      //],
-      "VoucherIssuedEvent": [
-      //  "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic",
-        "TransactionProcessor.BusinessLogic.EventHandling.VoucherDomainEventHandler, TransactionProcessor.BusinessLogic",
-      ],
-      //"VoucherFullyRedeemedEvent": [
-      //  "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic",
-      //  "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler,TransactionProcessor.BusinessLogic"
-      //],
       // Operator Domain Event Handler
       "OperatorCreatedEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
@@ -223,8 +201,7 @@
         "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"
       ],
       "StatementGeneratedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic",
-        "TransactionProcessor.BusinessLogic.EventHandling.MerchantDomainEventHandler, TransactionProcessor.BusinessLogic"
+        "TransactionProcessor.BusinessLogic.EventHandling.ReadModelDomainEventHandler, TransactionProcessor.BusinessLogic"//,
       ],
       // Settlement Domain Event Handler
       "SettlementCreatedForDateEvent": [
@@ -267,6 +244,9 @@
       ]
     },
     "EventHandlerConfigurationOrdered": {
+      "CallbackReceivedEnrichedEvent": [
+        "TransactionProcessor.BusinessLogic.EventHandling.MerchantDomainEventHandler,TransactionProcessor.BusinessLogic"
+      ],
       "EstateCreatedEvent": [
         "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine"
       ],
@@ -287,13 +267,15 @@
       ],
       "TransactionHasBeenCompletedEvent": [
         "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine",
-        "TransactionProcessor.BusinessLogic.EventHandling.MerchantStatementDomainEventHandler,TransactionProcessor.BusinessLogic"
+        "TransactionProcessor.BusinessLogic.EventHandling.MerchantStatementDomainEventHandler,TransactionProcessor.BusinessLogic",
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "CustomerEmailReceiptRequestedEvent": [
         "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "SettledMerchantFeeAddedToTransactionEvent": [
-        "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine"
+        "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine",
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
       ],
       "VoucherGeneratedEvent": [
         "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine"
@@ -308,10 +290,21 @@
         "TransactionProcessor.ProjectionEngine.EventHandling.EventHandler,TransactionProcessor.ProjectionEngine"
       ],
       "MerchantFeeSettledEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.MerchantSettlementDomainEventHandler,TransactionProcessor.BusinessLogic"
+        "TransactionProcessor.BusinessLogic.EventHandling.MerchantSettlementDomainEventHandler,TransactionProcessor.BusinessLogic",
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic",
       ],
       "StatementGeneratedEvent": [
-        "TransactionProcessor.BusinessLogic.EventHandling.MerchantStatementDomainEventHandler,TransactionProcessor.BusinessLogic"
+        "TransactionProcessor.BusinessLogic.EventHandling.MerchantStatementDomainEventHandler,TransactionProcessor.BusinessLogic",
+        "TransactionProcessor.BusinessLogic.EventHandling.MerchantDomainEventHandler, TransactionProcessor.BusinessLogic"
+      ],
+      "TransactionCostInformationRecordedEvent": [
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler, TransactionProcessor.BusinessLogic"
+      ],
+      "FloatCreditPurchasedEvent": [
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler, TransactionProcessor.BusinessLogic"
+      ],
+      "MerchantFeePendingSettlementAddedToTransactionEvent": [
+        "TransactionProcessor.BusinessLogic.EventHandling.TransactionDomainEventHandler,TransactionProcessor.BusinessLogic"
       ]
     },
     "EventStateConfig": {
@@ -338,7 +331,7 @@
           "IncludeGroups": "Transaction Processor",
           "IgnoreGroups": "Ordered,local-",
           "Enabled": true,
-          "InflightMessages": 500,
+          "InflightMessages": 20,
           "IsOrdered": false,
           "InstanceCount": 1
         },

--- a/TransactionProcessor/nlog.config
+++ b/TransactionProcessor/nlog.config
@@ -30,10 +30,10 @@
 	Error - Error messages
 	Fatal - Fatal error messages. After a fatal error, the application usually terminates
 	-->
-
+s
 	<rules>
 		<logger name="Microsoft.*" minlevel="Warn" writeTo="" final="true" />
-		<logger name="*" minlevel="Trace" writeTo="logfile">
+		<logger name="*" minlevel="Warn" writeTo="logfile">
 			<filters defaultAction="Log">
 				<when condition="contains('${message}', 'HEALTH_CHECK')" action="Ignore"></when>
 			</filters>


### PR DESCRIPTION
This commit updates the version numbers of several package references in the TransactionProcessor solution from `2025.1.x` to `2025.2.x`, including `ClientProxyBase`, `Shared`, `Shared.EventStore`, and `Shared.DomainDrivenDesign`.

Modifications in `appsettings.json` include the addition of the `CallbackReceivedEnrichedEvent` handler and the removal of several transaction-related event handlers, indicating a refactor in event handling logic.

The `nlog.config` file has been updated to change the minimum log level from `Trace` to `Warn`, reducing log verbosity and focusing on more significant issues.

These changes aim to improve the application's performance and maintainability.