### PR TITLE
Update subscription entries in SubscriptionsHelper

### DIFF
--- a/TransactionProcessor.IntegrationTesting.Helpers/SubscriptionsHelper.cs
+++ b/TransactionProcessor.IntegrationTesting.Helpers/SubscriptionsHelper.cs
@@ -6,30 +6,26 @@ public static class SubscriptionsHelper
     {
         List<(String streamName, String groupName, Int32 maxRetries)> subscriptions = new(){
                                                                                                // Main
-                                                                                               ("$ce-EstateAggregate", "Transaction Processor", 2),
-                                                                                               ("$ce-SettlementAggregate", "Transaction Processor", 0),
-                                                                                               ("$ce-TransactionAggregate", "Transaction Processor", 0),
-                                                                                               ("$ce-OperatorAggregate", "Transaction Processor", 0),
-                                                                                               ("$ce-ContractAggregate", "Transaction Processor", 0),
-                                                                                               ("$ce-MerchantAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-CallbackMessageAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-ContractAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-EstateAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-FileAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-FileImportLogAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-FloatAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-MerchantAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-MerchantStatementAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-OperatorAggregate", "Transaction Processor", 0),
                                                                                                ("$ce-ReconciliationAggregate", "Transaction Processor", 0),
-                                                                                               //("$ce-VoucherAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-SettlementAggregate", "Transaction Processor", 0),
+                                                                                               ("$ce-TransactionAggregate", "Transaction Processor", 0),
 
                                                                                                // Ordered
-                                                                                               //("$ce-EstateAggregate", "Transaction Processor - Ordered", 2),
                                                                                                ("$ce-MerchantAggregate", "Transaction Processor - Ordered", 2),
-                                                                                               ("" +
-                                                                                                "$ce-MerchantDepositListAggregate", "Transaction Processor - Ordered", 2),
+                                                                                               ("$ce-MerchantStatementAggregate", "Transaction Processor - Ordered", 0),
+                                                                                               ("$ce-SettlementAggregate", "Transaction Processor - Ordered", 1),
                                                                                                ("$ce-TransactionAggregate", "Transaction Processor - Ordered", 2),
                                                                                                ("$ce-VoucherAggregate", "Transaction Processor - Ordered", 2),
-                                                                                               ("$ce-MerchantStatementAggregate", "Transaction Processor - Ordered", 0)
-                                                                                               
-                                                                                               
+                                                                                               ("$ce-MerchantDepositListAggregate", "Transaction Processor - Ordered", 2),
                                                                                            };
 
         return subscriptions;


### PR DESCRIPTION
Modified the `GetSubscriptions` method to refresh the list of subscriptions. Removed entries for `"$ce-EstateAggregate"`, `"$ce-SettlementAggregate"`, `"$ce-TransactionAggregate"`, `"$ce-OperatorAggregate"`, and `"$ce-MerchantAggregate"`. Added back entries for `"$ce-ContractAggregate"`, `"$ce-EstateAggregate"`, `"$ce-MerchantAggregate"`, `"$ce-OperatorAggregate"`, `"$ce-SettlementAggregate"`, and `"$ce-TransactionAggregate"`. Updated the "Ordered" section by adding `"$ce-MerchantDepositListAggregate"` and removing `"$ce-MerchantStatementAggregate"`.