### PR TITLE
Refactor FloatDomainService to use IAggregateService

### DIFF
--- a/TransactionProcessor.Aggregates/FloatActivityAggregate.cs
+++ b/TransactionProcessor.Aggregates/FloatActivityAggregate.cs
@@ -8,7 +8,6 @@ namespace TransactionProcessor.Aggregates
 {
     public static class FloatActivityAggregateExtensions
     {
-
         public static void PlayEvent(this FloatActivityAggregate aggregate,
                                      FloatActivityDomainEvents.FloatAggregateCreditedEvent domainEvent)
         {

--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantDomainEventHandlerTests.cs
@@ -12,6 +12,7 @@ using TransactionProcessor.Aggregates;
 using TransactionProcessor.BusinessLogic.EventHandling;
 using TransactionProcessor.BusinessLogic.Events;
 using TransactionProcessor.BusinessLogic.Requests;
+using TransactionProcessor.BusinessLogic.Services;
 using TransactionProcessor.DomainEvents;
 using TransactionProcessor.Repository;
 using TransactionProcessor.Testing;
@@ -22,16 +23,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers
 {
     public class MerchantDomainEventHandlerTests : DomainEventHandlerTests
     {
-        private readonly Mock<IAggregateRepository<MerchantAggregate, DomainEvent>> MerchantAggregateRepository;
         private readonly Mock<ITransactionProcessorReadModelRepository> TransactionProcessorReadModelRepository;
         private readonly MerchantDomainEventHandler DomainEventHandler;
 
         public MerchantDomainEventHandlerTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)  {
-            this.MerchantAggregateRepository = new Mock<IAggregateRepository<MerchantAggregate, DomainEvent>>();
             this.TransactionProcessorReadModelRepository = new Mock<ITransactionProcessorReadModelRepository>();
 
-            this.DomainEventHandler = new MerchantDomainEventHandler(this.MerchantAggregateRepository.Object,
-                                                                     this.TransactionProcessorReadModelRepository.Object,
+            this.DomainEventHandler = new MerchantDomainEventHandler(this.TransactionProcessorReadModelRepository.Object,
                                                                      this.Mediator.Object);
         }
 

--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/VoucherDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/VoucherDomainEventHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using SimpleResults;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Services;
 using TransactionProcessor.Database.Contexts;
 using TransactionProcessor.Database.Entities;
 
@@ -67,8 +68,8 @@ public class VoucherDomainEventHandlerTests
         Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
         securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse()));
 
-        Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
-        voucherAggregateRepository.Setup(t => t.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        Mock<IAggregateService> aggregateService = new();
+        aggregateService.Setup(t => t.Get<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                   .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientEmail()));
 
         EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"), TestDatabaseType.InMemory);
@@ -98,7 +99,7 @@ public class VoucherDomainEventHandlerTests
                                                        });
 
         VoucherDomainEventHandler voucherDomainEventHandler = new VoucherDomainEventHandler(securityServiceClient.Object,
-                                                                                            voucherAggregateRepository.Object,
+                                                                                            aggregateService.Object,
                                                                                             dbContextFactory.Object,
                                                                                             messagingServiceClient.Object,
                                                                                             fileSystem);
@@ -116,8 +117,8 @@ public class VoucherDomainEventHandlerTests
         Mock<ISecurityServiceClient> securityServiceClient = new Mock<ISecurityServiceClient>();
         securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse()));
 
-        Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
-        voucherAggregateRepository.Setup(t => t.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        Mock<IAggregateService> aggregateService = new ();
+        aggregateService.Setup(t => t.Get<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                   .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
 
         EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"), TestDatabaseType.InMemory);
@@ -147,7 +148,7 @@ public class VoucherDomainEventHandlerTests
                                                        });
 
         VoucherDomainEventHandler voucherDomainEventHandler = new VoucherDomainEventHandler(securityServiceClient.Object,
-                                                                                            voucherAggregateRepository.Object,
+                                                                                            aggregateService.Object,
                                                                                             dbContextFactory.Object,
                                                                                             messagingServiceClient.Object,
                                                                                             fileSystem);

--- a/TransactionProcessor.BusinessLogic.Tests/Manager/VoucherManagementManagerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Manager/VoucherManagementManagerTests.cs
@@ -10,6 +10,7 @@ using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Aggregates;
 using TransactionProcessor.BusinessLogic.Manager;
+using TransactionProcessor.BusinessLogic.Services;
 using TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers;
 using TransactionProcessor.Database.Contexts;
 using TransactionProcessor.Database.Entities;
@@ -65,10 +66,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
             Mock<IDbContextFactory<EstateManagementGenericContext>> dbContextFactory = this.GetMockDbContextFactory();
             dbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
 
-            Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
-            voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
+            Mock<IAggregateService> aggregateService = new();
+            aggregateService.Setup(v => v.Get<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
 
-            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, voucherAggregateRepository.Object);
+            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, aggregateService.Object);
 
             Models.Voucher voucher = await manager.GetVoucherByCode(TestData.EstateId, TestData.VoucherCode, CancellationToken.None);
 
@@ -85,9 +86,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
             Mock<IDbContextFactory<EstateManagementGenericContext>> dbContextFactory = this.GetMockDbContextFactory();
             dbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
 
-            Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
+            Mock<IAggregateService> aggregateService = new();
+            aggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.NotFound());
 
-            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, voucherAggregateRepository.Object);
+            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, aggregateService.Object);
 
             Should.Throw<NotFoundException>(async () =>
             {
@@ -114,10 +116,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
             Mock<IDbContextFactory<EstateManagementGenericContext>> dbContextFactory = this.GetMockDbContextFactory();
             dbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
 
-            Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
-            voucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
+            Mock<IAggregateService> aggregateService = new();
+            aggregateService.Setup(v => v.Get<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
 
-            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, voucherAggregateRepository.Object);
+            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, aggregateService.Object);
 
             Models.Voucher voucher = await manager.GetVoucherByTransactionId(TestData.EstateId, TestData.TransactionId, CancellationToken.None);
 
@@ -134,9 +136,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
             Mock<IDbContextFactory<EstateManagementGenericContext>> dbContextFactory = this.GetMockDbContextFactory();
             dbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
 
-            Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> voucherAggregateRepository = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
+            Mock<IAggregateService> aggregateService = new();
+            aggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.NotFound());
 
-            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, voucherAggregateRepository.Object);
+            VoucherManagementManager manager = new VoucherManagementManager(dbContextFactory.Object, aggregateService.Object);
 
             Should.Throw<NotFoundException>(async () =>
             {

--- a/TransactionProcessor.BusinessLogic.Tests/RequestHandler/SettlementRequestHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/RequestHandler/SettlementRequestHandlerTests.cs
@@ -21,9 +21,9 @@ public class SettlementRequestHandlerTests
     public async Task SettlementRequestHandler_ProcessSettlementRequest_IsHandled()
     {
         Mock<ISettlementDomainService> settlementDomainService = new Mock<ISettlementDomainService>();
-        Mock<IAggregateRepository<SettlementAggregate, DomainEvent>> settlementAggregateRepository = new();
+        Mock<IAggregateService> aggregateService = new();
         Mock<ITransactionProcessorManager> manager = new Mock<ITransactionProcessorManager>();
-        SettlementRequestHandler handler = new SettlementRequestHandler(settlementDomainService.Object, settlementAggregateRepository.Object, manager.Object);
+        SettlementRequestHandler handler = new SettlementRequestHandler(settlementDomainService.Object, aggregateService.Object, manager.Object);
         settlementDomainService
             .Setup(s => s.ProcessSettlement(It.IsAny<SettlementCommands.ProcessSettlementCommand>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
         var command = TestData.Commands.ProcessSettlementCommand;

--- a/TransactionProcessor.BusinessLogic.Tests/Services/EstateDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/EstateDomainServiceTests.cs
@@ -19,21 +19,21 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 {
     public class EstateDomainServiceTests {
         private EstateDomainService DomainService;
-        private Mock<IAggregateRepository<EstateAggregate, DomainEvent>> EstateAggregateRepository;
+        private Mock<IAggregateService> AggregateService;
         private Mock<ISecurityServiceClient> SecurityServiceClient;
         public EstateDomainServiceTests() {
-            this.EstateAggregateRepository = new Mock<IAggregateRepository<EstateAggregate, DomainEvent>>();
+            this.AggregateService= new Mock<IAggregateService>();
             this.SecurityServiceClient = new Mock<ISecurityServiceClient>();
-            this.DomainService = new EstateDomainService(this.EstateAggregateRepository.Object, this.SecurityServiceClient.Object);
+            this.DomainService = new EstateDomainService(this.AggregateService.Object, this.SecurityServiceClient.Object);
         }
 
         [Fact]
         public async Task EstateDomainService_CreateEstate_EstateIsCreated() {
             
-            this.EstateAggregateRepository.Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success(new EstateAggregate()));
-            this.EstateAggregateRepository
-                .Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success());
             
             Result result = await this.DomainService.CreateEstate(TestData.Commands.CreateEstateCommand, CancellationToken.None);
@@ -44,8 +44,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_AddOperatorEstate_OperatorIsAdded()
         {
-            this.EstateAggregateRepository.Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-            this.EstateAggregateRepository.Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success());
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success());
 
             Result result = await this.DomainService.AddOperatorToEstate(TestData.Commands.AddOperatorToEstateCommand, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
@@ -54,19 +55,17 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_RemoveOperatorFromEstate_OperatorIsRemoved()
         {
-            this.EstateAggregateRepository.Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
-            this.EstateAggregateRepository.Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
             Result result = await this.DomainService.RemoveOperatorFromEstate(TestData.Commands.RemoveOperatorFromEstateCommand, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task EstateDomainService_CreateEstateUser_EstateUserIsCreated() {
-            this.EstateAggregateRepository
-                .Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-            this.EstateAggregateRepository
-                .Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success());
 
             this.SecurityServiceClient
@@ -87,11 +86,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_CreateEstateUser_UserCreateFailed_ResultIsFailed()
         {
-            this.EstateAggregateRepository
-                .Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-            this.EstateAggregateRepository
-                .Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success());
 
             this.SecurityServiceClient
@@ -112,11 +109,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_CreateEstateUser_GetUsersFailed_ResultIsFailed()
         {
-            this.EstateAggregateRepository
-                .Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-            this.EstateAggregateRepository
-                .Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success());
 
             this.SecurityServiceClient
@@ -133,11 +128,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_CreateEstateUser_NullUserReturned_ResultIsFailed()
         {
-            this.EstateAggregateRepository
-                .Setup(m => m.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-            this.EstateAggregateRepository
-                .Setup(m => m.SaveChanges(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success());
 
             this.SecurityServiceClient

--- a/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
@@ -53,7 +53,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task FloatDomainService_CreateFloatForContractProduct_InvalidEstate_ErrorThrown()
         {
-            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyEstateAggregate);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.NotFound());
             FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);
             Result result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
@@ -64,7 +64,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task FloatDomainService_CreateFloatForContractProduct_InvalidContract_ErrorThrown()
         {
             this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
-            this.AggregateService.Setup(f => f.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyContractAggregate);
+            this.AggregateService.Setup(f => f.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.NotFound());
 
             FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);

--- a/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/FloatDomainServiceTests.cs
@@ -20,11 +20,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
     public class FloatDomainServiceTests
     {
-        private readonly Mock<IAggregateRepository<FloatAggregate, DomainEvent>> FloatAggregateRepository;
-        private readonly Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>> FloatActivityAggregateRepository;
-        private readonly Mock<IAggregateRepository<TransactionAggregate, DomainEvent>> TransactionAggregateRepository;
-        private readonly Mock<IAggregateRepository<EstateAggregate, DomainEvent>> EstateAggregateRepository;
-        private readonly Mock<IAggregateRepository<ContractAggregate,DomainEvent>> ContractAggregateRepository;
+        private readonly Mock<IAggregateService> AggregateService;
         private readonly FloatDomainService FloatDomainService;
 
         public FloatDomainServiceTests(){
@@ -34,69 +30,57 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            this.FloatAggregateRepository = new Mock<IAggregateRepository<FloatAggregate, DomainEvent>>();
-            this.FloatActivityAggregateRepository = new Mock<IAggregateRepository<FloatActivityAggregate, DomainEvent>>();
-            this.TransactionAggregateRepository = new Mock<IAggregateRepository<TransactionAggregate, DomainEvent>>();
-            this.EstateAggregateRepository = new Mock<IAggregateRepository<EstateAggregate, DomainEvent>>();
-            this.ContractAggregateRepository = new Mock<IAggregateRepository<ContractAggregate, DomainEvent>>();
+            this.AggregateService = new Mock<IAggregateService>();
 
-            this.FloatDomainService = new FloatDomainService(this.FloatAggregateRepository.Object,
-                this.FloatActivityAggregateRepository.Object,
-                this.TransactionAggregateRepository.Object,
-                this.EstateAggregateRepository.Object,
-                this.ContractAggregateRepository.Object);
+            this.FloatDomainService = new FloatDomainService(this.AggregateService.Object);
         }
 
         [Fact]
         public async Task FloatDomainService_CreateFloatForContractProduct_FloatCreated(){
 
-            this.EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync( Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(f => f.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedContractAggregateWithAProductAndTransactionFee(Models.Contract.CalculationType.Fixed, Models.Contract.FeeType.Merchant)));
 
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FloatAggregate());
-            this.FloatAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
-            this.ContractAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedContractAggregateWithAProductAndTransactionFee(Models.Contract.CalculationType.Fixed,Models.Contract.FeeType.Merchant));
-            var command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
+            this.AggregateService.Setup(f => f.GetLatest<FloatAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.GetEmptyFloatAggregate()));
+            this.AggregateService.Setup(f => f.Save<FloatAggregate>(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
+
+            FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);
-            var result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task FloatDomainService_CreateFloatForContractProduct_InvalidEstate_ErrorThrown()
         {
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FloatAggregate());
-            this.EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
-            
-            var command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyEstateAggregate);
+            FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);
-            var result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task FloatDomainService_CreateFloatForContractProduct_InvalidContract_ErrorThrown()
         {
-            this.EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FloatAggregate());
-            this.ContractAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.NotFound());
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(f => f.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyContractAggregate);
 
-            var command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
+            FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);
-            var result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task FloatDomainService_CreateFloatForContractProduct_InvalidContractProduct_ErrorThrown()
         {
-            this.ContractAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedContractAggregate());
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(f => f.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedContractAggregate()));
 
-            this.EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FloatAggregate());
-
-            var command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
+            FloatCommands.CreateFloatForContractProductCommand command = new FloatCommands.CreateFloatForContractProductCommand(TestData.EstateId, TestData.ContractId,
                 TestData.ProductId, TestData.FloatCreatedDateTime);
-            var result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.CreateFloatForContractProduct(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
@@ -104,13 +88,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task FloatDomainService_RecordCreditPurchase_PurchaseRecorded(){
             FloatAggregate floatAggregate = FloatAggregate.Create(TestData.FloatAggregateId);
             floatAggregate.CreateFloat(TestData.EstateId, TestData.ContractId, TestData.ProductId, TestData.FloatCreatedDateTime);
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
-            
-            var command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
+            this.AggregateService.Setup(f => f.GetLatest<FloatAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatAggregate>(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
+
+            FloatCommands.RecordCreditPurchaseForFloatCommand command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.FloatCreditAmount, TestData.FloatCreditCostPrice,
                 TestData.CreditPurchasedDateTime);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
@@ -119,13 +103,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         {
             FloatAggregate floatAggregate = FloatAggregate.Create(TestData.FloatAggregateId);
             floatAggregate.CreateFloat(TestData.EstateId, TestData.ContractId, TestData.ProductId, TestData.FloatCreatedDateTime);
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+            this.AggregateService.Setup(f => f.GetLatest<FloatAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatAggregate>(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
-            var command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
+            FloatCommands.RecordCreditPurchaseForFloatCommand command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.FloatCreditAmount, TestData.FloatCreditCostPrice,
                 TestData.CreditPurchasedDateTime);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
@@ -134,13 +118,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         {
             FloatAggregate floatAggregate = FloatAggregate.Create(TestData.FloatAggregateId);
             floatAggregate.CreateFloat(TestData.EstateId, TestData.ContractId, TestData.ProductId, TestData.FloatCreatedDateTime);
-            this.FloatAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+            this.AggregateService.Setup(f => f.GetLatest<FloatAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatAggregate>(It.IsAny<FloatAggregate>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
 
-            var command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
+            FloatCommands.RecordCreditPurchaseForFloatCommand command = new FloatCommands.RecordCreditPurchaseForFloatCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.FloatCreditAmount, TestData.FloatCreditCostPrice,
                 TestData.CreditPurchasedDateTime);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
@@ -148,12 +132,12 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task FloatDomainService_RecordCreditPurchase_FloatActivity_PurchaseRecorded()
         {
             FloatActivityAggregate floatAggregate = FloatActivityAggregate.Create(TestData.FloatAggregateId);
-            this.FloatActivityAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatActivityAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+            this.AggregateService.Setup(f => f.GetLatest<FloatActivityAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatActivityAggregate>(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
 
-            var command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
+            FloatActivityCommands.RecordCreditPurchaseCommand command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.CreditPurchasedDateTime, TestData.FloatCreditAmount, TestData.FloatCreditId);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
@@ -161,12 +145,12 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task FloatDomainService_RecordCreditPurchase_FloatActivity_SaveFailed()
         {
             FloatActivityAggregate floatAggregate = FloatActivityAggregate.Create(TestData.FloatAggregateId);
-            this.FloatActivityAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatActivityAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
+            this.AggregateService.Setup(f => f.GetLatest<FloatActivityAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatActivityAggregate>(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure);
 
-            var command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
+            FloatActivityCommands.RecordCreditPurchaseCommand command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.CreditPurchasedDateTime, TestData.FloatCreditAmount, TestData.FloatCreditId);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
@@ -174,12 +158,12 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task FloatDomainService_RecordCreditPurchase_FloatActivity_ExceptionThrown()
         {
             FloatActivityAggregate floatAggregate = FloatActivityAggregate.Create(TestData.FloatAggregateId);
-            this.FloatActivityAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(floatAggregate);
-            this.FloatActivityAggregateRepository.Setup(f => f.SaveChanges(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+            this.AggregateService.Setup(f => f.GetLatest<FloatActivityAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(floatAggregate));
+            this.AggregateService.Setup(f => f.Save<FloatActivityAggregate>(It.IsAny<FloatActivityAggregate>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
 
-            var command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
+            FloatActivityCommands.RecordCreditPurchaseCommand command = new FloatActivityCommands.RecordCreditPurchaseCommand(TestData.EstateId,
                 TestData.FloatAggregateId, TestData.CreditPurchasedDateTime, TestData.FloatCreditAmount, TestData.FloatCreditId);
-            var result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
+            Result result = await this.FloatDomainService.RecordCreditPurchase(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
     }

--- a/TransactionProcessor.BusinessLogic.Tests/Services/MerchantDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/MerchantDomainServiceTests.cs
@@ -788,7 +788,7 @@ public class MerchantDomainServiceTests {
             .Setup(m => m.Save(It.IsAny<MerchantAggregate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success);
         this.AggregateService.Setup(c => c.Get<ContractAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(TestData.Aggregates.EmptyContractAggregate);
+            .ReturnsAsync(Result.NotFound());
 
         var result = await this.DomainService.AddContractToMerchant(TestData.Commands.AddMerchantContractCommand, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();

--- a/TransactionProcessor.BusinessLogic.Tests/Services/OperatorDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/OperatorDomainServiceTests.cs
@@ -16,24 +16,21 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services;
 public class OperatorDomainServiceTests{
 
     private IOperatorDomainService OperatorDomainService;
-    private Mock<IAggregateRepository<EstateAggregate, DomainEvent>> EstateAggregateRepository;
-    private Mock<IAggregateRepository<OperatorAggregate, DomainEvent>> OperatorAggregateRepository;
+    private Mock<IAggregateService> AggregateService;
 
     public OperatorDomainServiceTests(){
-        this.EstateAggregateRepository = new Mock<IAggregateRepository<EstateAggregate, DomainEvent>>();
-        this.OperatorAggregateRepository= new Mock<IAggregateRepository<OperatorAggregate, DomainEvent>>();
-        this.OperatorDomainService = new OperatorDomainService(this.EstateAggregateRepository.Object,
-                                                               this.OperatorAggregateRepository.Object);
+        this.AggregateService = new Mock<IAggregateService>();
+        this.OperatorDomainService = new OperatorDomainService(this.AggregateService.Object);
     }
 
     [Fact]
     public async Task OperatorDomainService_CreateOperator_OperatorIsCreated(){
-        this.EstateAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                                 .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+        this.AggregateService.Setup(e => e.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                                 .ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate());
 
-        this.OperatorAggregateRepository.Setup(o => o.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
-        this.OperatorAggregateRepository
-            .Setup(o => o.SaveChanges(It.IsAny<OperatorAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
+        this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
+        this.AggregateService
+            .Setup(o => o.Save(It.IsAny<OperatorAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
         Result result = await this.OperatorDomainService.CreateOperator(TestData.Commands.CreateOperatorCommand, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
 
@@ -42,9 +39,9 @@ public class OperatorDomainServiceTests{
     [Fact]
     public async Task OperatorDomainService_CreateOperator_EstateNotCreated_ResultFailed()
     {
-        this.EstateAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        this.AggregateService.Setup(e => e.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(TestData.Aggregates.EmptyEstateAggregate);
-        this.OperatorAggregateRepository.Setup(o => o.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
+        this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
 
         Result result = await this.OperatorDomainService.CreateOperator(TestData.Commands.CreateOperatorCommand, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -53,11 +50,10 @@ public class OperatorDomainServiceTests{
 
     [Fact]
     public async Task OperatorDomainService_CreateOperator_OperatorAlreadyCreated_ResultFailed() {
-        this.EstateAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+        this.AggregateService.Setup(e => e.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate());
 
-        this.OperatorAggregateRepository.Setup(o => o.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
+        this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
 
         Result result = await this.OperatorDomainService.CreateOperator(TestData.Commands.CreateOperatorCommand, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
@@ -66,11 +62,11 @@ public class OperatorDomainServiceTests{
     [Fact]
     public async Task OperatorDomainService_UpdateOperator_OperatorIsUpdated()
     {
-        this.EstateAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
-        this.OperatorAggregateRepository.Setup(o => o.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
-        this.OperatorAggregateRepository
-            .Setup(o => o.SaveChanges(It.IsAny<OperatorAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
+        this.AggregateService.Setup(e => e.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate());
+        this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
+        this.AggregateService
+            .Setup(o => o.Save(It.IsAny<OperatorAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success());
         Result result = await this.OperatorDomainService.UpdateOperator(TestData.Commands.UpdateOperatorCommand, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
     }
@@ -78,7 +74,7 @@ public class OperatorDomainServiceTests{
     [Fact]
     public async Task OperatorDomainService_UpdateOperator_OperatorNotCreated_ResultFailed()
     {
-        this.OperatorAggregateRepository.Setup(o => o.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
+        this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.EmptyOperatorAggregate()));
 
         Result result = await this.OperatorDomainService.UpdateOperator(TestData.Commands.UpdateOperatorCommand, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();

--- a/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
@@ -318,7 +318,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
             this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TestData.Aggregates.EmptyMerchantAggregate);
+                .ReturnsAsync(Result.NotFound());
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 

--- a/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/SettlementDomainServiceTests.cs
@@ -22,22 +22,15 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
     public class SettlementDomainServiceTests
     {
-        private Mock<IAggregateRepository<TransactionAggregate, DomainEvent>> transactionAggregateRepository;
-        private Mock<IAggregateRepository<SettlementAggregate, DomainEvent>> settlementAggregateRepository;
-        private Mock<IAggregateRepository<MerchantAggregate, DomainEvent>> merchantAggregateRepository;
+        private Mock<IAggregateService> AggregateService;
         private SettlementDomainService settlementDomainService;
 
         public SettlementDomainServiceTests() {
-            this.transactionAggregateRepository =
-                new Mock<IAggregateRepository<TransactionAggregate, DomainEvent>>();
-            this.settlementAggregateRepository =
-                new Mock<IAggregateRepository<SettlementAggregate, DomainEvent>>();
-            this.merchantAggregateRepository =
-                new Mock<IAggregateRepository<MerchantAggregate, DomainEvent>>();
+            this.AggregateService =
+                new Mock<IAggregateService>();
             
             this.settlementDomainService =
-                new SettlementDomainService(this.transactionAggregateRepository.Object, settlementAggregateRepository.Object,
-                                            merchantAggregateRepository.Object);
+                new SettlementDomainService(this.AggregateService.Object);
 
             IConfigurationRoot configurationRoot = new ConfigurationBuilder().AddInMemoryCollection(TestData.DefaultAppSettings).Build();
             ConfigurationReader.Initialise(configurationRoot);
@@ -48,23 +41,23 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_SettlementIsProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetSettlementAggregateWithPendingMerchantFees(10)));
-            this.transactionAggregateRepository.SetupSequence(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(0)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(1)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(2)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(3)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(4)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(5)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(6)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(7)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(8)))
-                .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(9)));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.GetLatest<TransactionAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(0))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(1))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(2))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(3))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(4))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(5))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(6))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(7))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(8))))
+                .ReturnsAsync(Result.Success(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(9))));
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.transactionAggregateRepository.SetupSequence(s => s.SaveChanges(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.Save(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
@@ -76,14 +69,14 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success());
 
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.ProcessSettlementCommand command =
                 new(TestData.SettlementDate, TestData.MerchantId,
                     TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
 
             result.IsSuccess.ShouldBeTrue();
             result.Data.ShouldNotBe(Guid.Empty);
@@ -92,9 +85,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_MerchantWithImmediateSettlement_SettlementIsProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetSettlementAggregateWithPendingMerchantFees(10)));
-            this.transactionAggregateRepository.SetupSequence(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.GetLatest<TransactionAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(0)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(1)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(2)))
@@ -105,10 +98,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(7)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(8)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(9)));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.transactionAggregateRepository.SetupSequence(s => s.SaveChanges(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.Save(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
@@ -121,14 +114,14 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .ReturnsAsync(Result.Success());
 
 
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.ProcessSettlementCommand command =
                 new(TestData.SettlementDate, TestData.MerchantId,
                     TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
 
             result.IsSuccess.ShouldBeTrue();
             result.Data.ShouldNotBe(Guid.Empty);
@@ -137,17 +130,17 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_SettlementAggregateNotCreated_NothingProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetEmptySettlementAggregate()));
-            settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success());
 
             SettlementCommands.ProcessSettlementCommand command =
                 new(TestData.SettlementDate, TestData.MerchantId,
                     TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
 
             result.IsSuccess.ShouldBeTrue();
             result.Data.ShouldNotBe(Guid.Empty);
@@ -156,18 +149,18 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_SettlementAggregateNoFeesToSettles_NothingProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.ProcessSettlementCommand command =
                 new(TestData.SettlementDate, TestData.MerchantId,
                     TestData.EstateId);
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
 
             result.IsSuccess.ShouldBeTrue();
             result.Data.ShouldNotBe(Guid.Empty);
@@ -176,13 +169,13 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_AddSettledFeeThrownException_SettlementProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetSettlementAggregateWithPendingMerchantFees(10)));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
 
-            this.transactionAggregateRepository.SetupSequence(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.GetLatest<TransactionAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(0)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(1)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(2)))
@@ -193,7 +186,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(7)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(8)))
                 .ReturnsAsync(TestData.GetCompletedAuthorisedSaleTransactionAggregateWithPendingFee(TestData.FeeIds.GetValueOrDefault(9)));
-            this.transactionAggregateRepository.SetupSequence(s => s.SaveChanges(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.SetupSequence(s => s.Save(It.IsAny<TransactionAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success())
@@ -205,165 +198,165 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                 .ReturnsAsync(Result.Success())
                 .ReturnsAsync(Result.Success());
 
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.ProcessSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_GetTransactionThrownException_SettlementProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                          .ReturnsAsync(Result.Success(TestData.GetSettlementAggregateWithPendingMerchantFees(10)));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
 
-            this.transactionAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<TransactionAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception());
 
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.ProcessSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_ProcessSettlement_GetMerchantThrownException_SettlementProcessed()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetSettlementAggregateWithPendingMerchantFees(10)));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
 
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception());
 
             SettlementCommands.ProcessSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId);
 
-            var result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
+            Result<Guid> result = await settlementDomainService.ProcessSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddMerchantFeePendingSettlement_FeeAdded() {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
 
             SettlementCommands.AddMerchantFeePendingSettlementCommand command = new(TestData.TransactionId, TestData.CalculatedFeeValue, TestData.TransactionFeeCalculateDateTime, CalculationType.Fixed, TestData.TransactionFeeId, TestData.TransactionFeeValue, TestData.TransactionFeeSettlementDueDate, TestData.MerchantId, TestData.EstateId);
 
-            var result = await settlementDomainService.AddMerchantFeePendingSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddMerchantFeePendingSettlement(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddMerchantFeePendingSettlement_AggregateNotCreated_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetEmptySettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
 
             SettlementCommands.AddMerchantFeePendingSettlementCommand command = new(TestData.TransactionId, TestData.CalculatedFeeValue, TestData.TransactionFeeCalculateDateTime, CalculationType.Fixed, TestData.TransactionFeeId, TestData.TransactionFeeValue, TestData.TransactionFeeSettlementDueDate, TestData.MerchantId, TestData.EstateId);
 
-            var result = await settlementDomainService.AddMerchantFeePendingSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddMerchantFeePendingSettlement(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddSettledFeeToSettlement_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 
-            var result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddSettledFeeToSettlement_ImmediateSettlement_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 
-            var result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddSettledFeeToSettlement_FailedGettingMerchant_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Result.Failure());
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TestData.Aggregates.EmptyMerchantAggregate);
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 
-            var result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddSettledFeeToSettlement_SaveFailed_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Failure);
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 
-            var result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
         public async Task SettlementDomainService_AddSettledFeeToSettlement_ExceptionThrown_FeeAdded()
         {
-            settlementAggregateRepository.Setup(s => s.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(s => s.GetLatest<SettlementAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success(TestData.GetCreatedSettlementAggregate()));
-            this.settlementAggregateRepository
-                .Setup(s => s.SaveChanges(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService
+                .Setup(s => s.Save(It.IsAny<SettlementAggregate>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception());
-            this.merchantAggregateRepository.Setup(e => e.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(e => e.Get<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TestData.Aggregates.CreatedMerchantAggregate());
 
             SettlementCommands.AddSettledFeeToSettlementCommand command = new(TestData.SettlementDate, TestData.MerchantId, TestData.EstateId, TestData.TransactionFeeId, TestData.TransactionId);
 
-            var result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
+            Result result = await settlementDomainService.AddSettledFeeToSettlement(command, CancellationToken.None);
             result.IsFailed.ShouldBeTrue();
         }
     }

--- a/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
@@ -25,8 +25,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
     {
         #region Methods
 
-        private Mock<IAggregateRepository<VoucherAggregate, DomainEvent>> VoucherAggregateRepository;
-        private Mock<IAggregateRepository<EstateAggregate, DomainEvent>> EstateAggregateRepository;
+        private Mock<IAggregateService> AggregateService;
         private Mock<Shared.EntityFramework.IDbContextFactory<EstateManagementGenericContext>> DbContextFactory;
         private VoucherDomainService VoucherDomainService;
         public VoucherDomainServiceTests() {
@@ -35,21 +34,18 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             Logger.Initialise(NullLogger.Instance);
 
-            this.VoucherAggregateRepository  = new Mock<IAggregateRepository<VoucherAggregate, DomainEvent>>();
-            this.EstateAggregateRepository = new Mock<IAggregateRepository<EstateAggregate, DomainEvent>>();
+            this.AggregateService  = new Mock<IAggregateService>();
             this.DbContextFactory = new Mock<Shared.EntityFramework.IDbContextFactory<EstateManagementGenericContext>>();
-            this.VoucherDomainService = new VoucherDomainService(VoucherAggregateRepository.Object,
-                DbContextFactory.Object,
-                EstateAggregateRepository.Object);
+            this.VoucherDomainService = new VoucherDomainService(this.AggregateService.Object, DbContextFactory.Object);
         }
 
         [Fact]
         public async Task VoucherDomainService_IssueVoucher_EstateWithNoOperators_ErrorThrown() {
             
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate());
             var result = await this.VoucherDomainService.IssueVoucher(TestData.VoucherId,
                                                                                  TestData.OperatorId,
                                                                                  TestData.EstateId,
@@ -101,8 +97,8 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
         [Fact]
         public async Task VoucherDomainService_IssueVoucher_InvalidEstate_ErrorThrown() {
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyEstateAggregate);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
@@ -121,8 +117,8 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
         [Fact]
         public async Task VoucherDomainService_IssueVoucher_OperatorNotSupportedByEstate_ErrorThrown() {
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EstateAggregateWithOperator);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
@@ -142,9 +138,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task VoucherDomainService_IssueVoucher_VoucherIssued() {
 
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new VoucherAggregate());
-            VoucherAggregateRepository.Setup(v => v.SaveChanges(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
+            this.AggregateService.Setup(v => v.Save(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EstateAggregateWithOperator);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
@@ -165,10 +161,10 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
         [Fact]
         public async Task VoucherDomainService_RedeemVoucher_InvalidEstate_ErrorThrown() {
-            
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+
+            AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                       .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EmptyEstateAggregate);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             context.VoucherProjectionStates.Add(new TransactionProcessor.Database.Entities.VoucherProjectionState() {
@@ -190,11 +186,11 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task VoucherDomainService_RedeemVoucher_VoucherRedeemed() {
 
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                       .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
-            VoucherAggregateRepository.Setup(v => v.SaveChanges(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(v => v.Save(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             context.VoucherProjectionStates.Add(new TransactionProcessor.Database.Entities.VoucherProjectionState() {
@@ -217,9 +213,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
         [Fact]
         public async Task VoucherDomainService_RedeemVoucher_VoucherNotFound_ErrorThrown() {
-            VoucherAggregateRepository.Setup(v => v.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                       .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
-            EstateAggregateRepository.Setup(f => f.GetLatestVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate);
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);

--- a/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/VoucherDomainServiceTests.cs
@@ -118,7 +118,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task VoucherDomainService_IssueVoucher_OperatorNotSupportedByEstate_ErrorThrown() {
             this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
-            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EstateAggregateWithOperator);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
@@ -140,7 +140,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
 
             this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(new VoucherAggregate()));
             this.AggregateService.Setup(v => v.Save(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success);
-            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.EstateAggregateWithOperator);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.EstateAggregateWithOperator()));
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);
@@ -190,7 +190,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
                                       .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
             this.AggregateService.Setup(v => v.Save(It.IsAny<VoucherAggregate>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result.Success);
-            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             context.VoucherProjectionStates.Add(new TransactionProcessor.Database.Entities.VoucherProjectionState() {
@@ -215,7 +215,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         public async Task VoucherDomainService_RedeemVoucher_VoucherNotFound_ErrorThrown() {
             this.AggregateService.Setup(v => v.GetLatest<VoucherAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                                       .ReturnsAsync(Result.Success(TestData.GetVoucherAggregateWithRecipientMobile()));
-            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(TestData.Aggregates.CreatedEstateAggregate);
+            this.AggregateService.Setup(f => f.Get<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
 
             EstateManagementGenericContext context = await this.GetContext(Guid.NewGuid().ToString("N"));
             DbContextFactory.Setup(d => d.GetContext(It.IsAny<Guid>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(context);

--- a/TransactionProcessor.BusinessLogic/EventHandling/MerchantDomainEventHandler.cs
+++ b/TransactionProcessor.BusinessLogic/EventHandling/MerchantDomainEventHandler.cs
@@ -13,6 +13,7 @@ using TransactionProcessor.Aggregates;
 using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Events;
 using TransactionProcessor.BusinessLogic.Requests;
+using TransactionProcessor.BusinessLogic.Services;
 using TransactionProcessor.Models.Merchant;
 using TransactionProcessor.Repository;
 using MakeMerchantDepositRequest = TransactionProcessor.DataTransferObjects.Requests.Merchant.MakeMerchantDepositRequest;
@@ -24,19 +25,14 @@ namespace TransactionProcessor.BusinessLogic.EventHandling
         #region Fields
 
         private readonly IMediator Mediator;
-
-        private readonly IAggregateRepository<MerchantAggregate, DomainEvent> MerchantAggregateRepository;
-
         private readonly ITransactionProcessorReadModelRepository EstateReportingRepository;
         #endregion
 
         #region Constructors
 
-        public MerchantDomainEventHandler(IAggregateRepository<MerchantAggregate, DomainEvent> merchantAggregateRepository,
-                                          ITransactionProcessorReadModelRepository estateReportingRepository,
+        public MerchantDomainEventHandler(ITransactionProcessorReadModelRepository estateReportingRepository,
                                           IMediator mediator)
         {
-            this.MerchantAggregateRepository = merchantAggregateRepository;
             this.EstateReportingRepository = estateReportingRepository;
             this.Mediator = mediator;
         }

--- a/TransactionProcessor.BusinessLogic/RequestHandlers/SettlementRequestHandler.cs
+++ b/TransactionProcessor.BusinessLogic/RequestHandlers/SettlementRequestHandler.cs
@@ -24,14 +24,14 @@ namespace TransactionProcessor.BusinessLogic.RequestHandlers
                                             IRequestHandler<SettlementQueries.GetSettlementsQuery, Result<List<SettlementModel>>>
     {
         private readonly ISettlementDomainService SettlementDomainService;
-        private readonly IAggregateRepository<SettlementAggregate, DomainEvent> SettlementAggregateRepository;
+        private readonly IAggregateService AggregateService;
         private readonly ITransactionProcessorManager TransactionProcessorManager;
 
         public SettlementRequestHandler(ISettlementDomainService settlementDomainService,
-                                        IAggregateRepository<SettlementAggregate, DomainEvent> settlementAggregateRepository,
+                                        IAggregateService aggregateService,
                                         ITransactionProcessorManager transactionProcessorManager) {
             this.SettlementDomainService = settlementDomainService;
-            this.SettlementAggregateRepository = settlementAggregateRepository;
+            this.AggregateService = aggregateService;
             this.TransactionProcessorManager = transactionProcessorManager;
         }
 
@@ -57,7 +57,7 @@ namespace TransactionProcessor.BusinessLogic.RequestHandlers
             // Convert the date passed in to a guid
             Guid aggregateId = Helpers.CalculateSettlementAggregateId(query.SettlementDate, query.MerchantId, query.EstateId);
             
-            Result<SettlementAggregate> getSettlementResult = await this.SettlementAggregateRepository.GetLatestVersion(aggregateId, cancellationToken);
+            Result<SettlementAggregate> getSettlementResult = await this.AggregateService.GetLatest<SettlementAggregate>(aggregateId, cancellationToken);
             if (getSettlementResult.IsFailed)
                 return getSettlementResult;
 

--- a/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
@@ -1,0 +1,365 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Prometheus;
+using Shared.DomainDrivenDesign.EventSourcing;
+using Shared.EventStore.Aggregate;
+using SimpleResults;
+using SixLabors.Fonts.Tables.AdvancedTypographic;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Shared.Logger;
+using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Services;
+
+namespace TransactionProcessor.BusinessLogic.Services {
+    public interface IAggregateRepositoryResolver {
+        IAggregateRepository<TAggregate, TEvent> Resolve<TAggregate, TEvent>() where TAggregate : Aggregate where TEvent : DomainEvent;
+    }
+
+    public class AggregateRepositoryResolver : IAggregateRepositoryResolver {
+        private readonly IServiceProvider _provider;
+
+        public AggregateRepositoryResolver(IServiceProvider provider) {
+            _provider = provider;
+        }
+
+        public IAggregateRepository<TAggregate, TEvent> Resolve<TAggregate, TEvent>() where TAggregate : Aggregate where TEvent : DomainEvent {
+            Type repoType = typeof(IAggregateRepository<,>).MakeGenericType(typeof(TAggregate), typeof(TEvent));
+            return (IAggregateRepository<TAggregate, TEvent>)_provider.GetRequiredService(repoType);
+        }
+    }
+
+    public interface IAggregateService {
+        Task<TAggregate> Get<TAggregate>(Guid aggregateId,
+                                         CancellationToken cancellationToken) where TAggregate : Aggregate, new();
+
+        Task<SimpleResults.Result<TAggregate>> GetLatest<TAggregate>(Guid aggregateId,
+                                                                     CancellationToken cancellationToken) where TAggregate : Aggregate, new();
+
+        Task<SimpleResults.Result<TAggregate>> GetLatestFromLastEvent<TAggregate>(Guid aggregateId,
+                                                                                  CancellationToken cancellationToken) where TAggregate : Aggregate, new();
+
+        Task<SimpleResults.Result<TAggregate>> GetLatestAggregateAsync<TAggregate>(Guid aggregateId,
+                                                                                   Func<IAggregateRepository<TAggregate, DomainEvent>, Guid, CancellationToken, Task<SimpleResults.Result<TAggregate>>> getLatestVersionFunc,
+                                                                                   CancellationToken cancellationToken) where TAggregate : Aggregate, new();
+
+        Task<Result> Save<TAggregate>(TAggregate aggregate,
+                                      CancellationToken cancellationToken) where TAggregate : Aggregate, new();
+    }
+
+    public class AggregateService : IAggregateService {
+        private readonly IAggregateRepositoryResolver AggregateRepositoryResolver;
+        private readonly AggregateMemoryCache Cache;
+        private readonly List<(Type, MemoryCacheEntryOptions, Object)> AggregateTypes;
+
+        public AggregateService(IAggregateRepositoryResolver aggregateRepositoryResolver,
+                                IMemoryCache cache) {
+            this.AggregateRepositoryResolver = aggregateRepositoryResolver;
+            this.Cache = new AggregateMemoryCache(cache);
+
+            //We update this list to contain MemoryCacheEntryOptions
+            // TODO: We might make this configurable in the future
+            this.AggregateTypes = new();
+
+            // Set default caching options
+            MemoryCacheEntryOptions memoryCacheEntryOptions = new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(30))
+                .RegisterPostEvictionCallback(AggregateService.EvictionCallback);
+
+            this.AggregateTypes.Add((typeof(EstateAggregate), memoryCacheEntryOptions, new Object()));
+        }
+
+        internal static void EvictionCallback(Object key,
+                                              Object value,
+                                              EvictionReason reason,
+                                              Object state)
+        {
+            Logger.LogWarning($"Key [{key}] of type [{value.GetType()}] removed from the cache {reason.ToString()}");
+        }
+
+        internal (Type, MemoryCacheEntryOptions, Object) GetAggregateType<TAggregate>() where TAggregate : Aggregate, new()
+        {
+            return this.AggregateTypes.SingleOrDefault(a => a.Item1 == typeof(TAggregate));
+        }
+
+        internal void SetCache<TAggregate>((Type, MemoryCacheEntryOptions, Object) aggregateType,
+                                           Aggregate aggregate) where TAggregate : Aggregate, new()
+        {
+            //Changed the trace here. 
+            //We have at least one scenario where something in aggregateType is null, and stopped us actually setting the cache!
+            //This approach should be safer.
+            if (aggregate == null)
+            {
+                Logger.LogWarning($"aggregate is null");
+            }
+
+            Logger.LogWarning($"About to save to cache.");
+
+            String g = typeof(TAggregate).Name;
+            String key = $"{g}-{aggregate.AggregateId}";
+
+            this.Cache.Set<TAggregate>(key, aggregate, aggregateType.Item2);
+        }
+
+        public async Task<TAggregate> Get<TAggregate>(Guid aggregateId,
+                                                  CancellationToken cancellationToken) where TAggregate : Aggregate, new()
+        {
+            (Type, MemoryCacheEntryOptions, Object) at = GetAggregateType<TAggregate>();
+            TAggregate aggregate = default;
+            String g = typeof(TAggregate).Name;
+            String key = $"{g}-{aggregateId}";
+
+            // Check the cache
+            if (at != default && this.Cache.TryGetValue(key, out aggregate))
+            {
+                return aggregate;
+            }
+
+            if (at == default)
+            {
+                // We don't use caching for this aggregate so just hit GetLatest
+                aggregate = await this.GetLatest<TAggregate>(aggregateId, cancellationToken);
+
+                if (aggregate == null)
+                {
+                    //We have encountered the situation where a timeout from the ES results in a null being pushed back through our aggregate repo
+                    //Don't want to change the library for a edge case situation, so compensating for this here.
+                    //We will ensure
+                    aggregate = new TAggregate();
+                }
+
+                return aggregate;
+            }
+
+            try
+            {
+                // Lock
+                Monitor.Enter(at.Item3);
+
+                if (this.Cache.TryGetValueWithMetrics<TAggregate>(key, out TAggregate cachedAggregate))
+                {
+                    return cachedAggregate;
+                }
+                else
+                {
+                    // Not found in cache so call GetLatest
+                    SimpleResults.Result<TAggregate> aggregateResult = this.GetLatest<TAggregate>(aggregateId, cancellationToken).Result;
+
+                    if (aggregateResult.IsSuccess)
+                    {
+                        aggregate = aggregateResult.Data;
+                        this.SetCache<TAggregate>(at, aggregateResult.Data);
+                    }
+                    else
+                    {
+                        Logger.LogWarning($"aggregateResult failed {aggregateResult.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                // Release
+                Monitor.Exit(at.Item3);
+            }
+
+            return aggregate;
+        }
+
+        public async Task<SimpleResults.Result<TAggregate>> GetLatest<TAggregate>(Guid aggregateId,
+                                                                                              CancellationToken cancellationToken) where TAggregate : Aggregate, new() {
+            return await this.GetLatestAggregateAsync<TAggregate>(aggregateId, (repo,
+                                                                                id,
+                                                                                cancellation) => repo.GetLatestVersion(id, cancellation), cancellationToken);
+        }
+
+        public async Task<SimpleResults.Result<TAggregate>> GetLatestFromLastEvent<TAggregate>(Guid aggregateId,
+                                                                                               CancellationToken cancellationToken) where TAggregate : Aggregate, new() {
+            return await this.GetLatestAggregateAsync<TAggregate>(aggregateId, (repo,
+                                                                                id,
+                                                                                cancellation) => repo.GetLatestVersionFromLastEvent(id, cancellation), cancellationToken);
+        }
+
+        public async Task<SimpleResults.Result<TAggregate>> GetLatestAggregateAsync<TAggregate>(Guid aggregateId,
+                                                                                                Func<IAggregateRepository<TAggregate, DomainEvent>, Guid, CancellationToken, Task<SimpleResults.Result<TAggregate>>> getLatestVersionFunc,
+                                                                                                CancellationToken cancellationToken) where TAggregate : Aggregate, new() {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            IAggregateRepository<TAggregate, DomainEvent> repository = this.AggregateRepositoryResolver.Resolve<TAggregate, DomainEvent>();
+
+            String g = typeof(TAggregate).Name;
+            String m = $"AggregateService";
+            Counter counterCalls = AggregateService.GetCounterMetric($"{m}_{g}_times_rehydrated");
+            Histogram histogramMetric = AggregateService.GetHistogramMetric($"{m}_{g}");
+
+            counterCalls.Inc();
+            TAggregate aggregate = null;
+            try {
+                var aggregateResult = await getLatestVersionFunc(repository, aggregateId, cancellationToken);
+                if (aggregateResult.IsFailed)
+                    return aggregateResult;
+                aggregate = aggregateResult.Data;
+            }
+            catch (Exception ex) {
+                return Result.Failure(ex.Message);
+            }
+
+            stopwatch.Stop();
+            histogramMetric.Observe(stopwatch.Elapsed.TotalSeconds);
+
+            return Result.Success(aggregate);
+        }
+
+
+        public async Task<Result> Save<TAggregate>(TAggregate aggregate,
+                                                           CancellationToken cancellationToken) where TAggregate : Aggregate, new() {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            IAggregateRepository<TAggregate, DomainEvent> repository = this.AggregateRepositoryResolver.Resolve<TAggregate, DomainEvent>();
+
+            String g = typeof(TAggregate).Name;
+            String m = $"AggregateService";
+            Counter counterCalls = AggregateService.GetCounterMetric($"{m}_{g}_times_saved");
+            Counter counterEvents = AggregateService.GetCounterMetric($"{m}_{g}_total_pending_events");
+            Histogram histogramMetric = AggregateService.GetHistogramMetric($"{m}_{g}");
+
+            counterCalls.Inc();
+
+            // TODO: Check the pending events so dont save blindly, this would need a change to the base aggregate ?
+            Result result = await repository.SaveChanges(aggregate, cancellationToken);
+
+            stopwatch.Stop();
+
+            histogramMetric.Observe(stopwatch.Elapsed.TotalSeconds);
+
+            if (result.IsFailed)
+            {
+                // Get out before any caching
+                return result;
+            }
+            
+            (Type, MemoryCacheEntryOptions, Object) at = GetAggregateType<TAggregate>();
+
+            if (at != default) {
+                this.SetCache<TAggregate>(at, aggregate);
+            }
+
+            return result;
+        }
+
+        public static readonly ConcurrentDictionary<String, Counter> DynamicCounter = new();
+
+        public static readonly ConcurrentDictionary<String, Histogram> DynamicHistogram = new();
+
+        private static readonly Func<String, String, String> FormatMetricName = (methodName,
+                                                                                 metricType) => $"eposity_{methodName}_{metricType}";
+
+        public static Histogram GetHistogramMetric(String methodName)
+        {
+            String n = AggregateService.FormatMetricName(methodName, nameof(Histogram).ToLower());
+
+            HistogramConfiguration histogramConfiguration = new()
+            {
+                Buckets = new[] { 1.0, 2.0, 5.0, 10.0, Double.PositiveInfinity }
+            };
+
+            var histogram = AggregateService.DynamicHistogram.GetOrAdd(methodName,
+                name => Metrics.CreateHistogram(name: n,
+                    help: $"Histogram of the execution time for {n}",
+                    histogramConfiguration));
+
+            return histogram;
+        }
+
+        public static Counter GetCounterMetric(String methodName)
+        {
+            String n = AggregateService.FormatMetricName(methodName, nameof(Counter).ToLower());
+
+            var counter = AggregateService.DynamicCounter.GetOrAdd(methodName, name => Metrics.CreateCounter(name: n, help: $"Total number times executed {n}"));
+
+            return counter;
+        }
+    }
+}
+
+
+public class AggregateMemoryCache
+{
+    private readonly IMemoryCache MemoryCache;
+
+    private readonly ConcurrentDictionary<String, Aggregate> KeyTracker;
+
+    public AggregateMemoryCache(IMemoryCache memoryCache)
+    {
+        this.MemoryCache = memoryCache;
+        this.KeyTracker = new ConcurrentDictionary<String, Aggregate>();
+    }
+
+    private static readonly Dictionary<Type, Boolean> CallbackRegistered = new();
+
+    private static readonly Object CallbackLock = new();
+
+    public void Set<TAggregate>(String key,
+                                Aggregate aggregate,
+                                MemoryCacheEntryOptions memoryCacheEntryOptions) where TAggregate : Aggregate, new()
+    {
+        Type aggregateType = typeof(TAggregate);
+
+        // Ensure the eviction callback is registered only once per TAggregate type
+        if (!AggregateMemoryCache.CallbackRegistered.TryGetValue(aggregateType, out Boolean isRegistered) || !isRegistered)
+        {
+            Monitor.Enter(AggregateMemoryCache.CallbackLock);
+
+            if (!AggregateMemoryCache.CallbackRegistered.TryGetValue(aggregateType, out isRegistered) || !isRegistered) // Double-check locking
+            {
+                // Register a callback to remove the item from our internal tracking
+                memoryCacheEntryOptions.RegisterPostEvictionCallback((evictedKey,
+                                                                      evictedValue,
+                                                                      reason,
+                                                                      state) => {
+                                                                          this.KeyTracker.TryRemove(evictedKey.ToString(), out _);
+                                                                      });
+
+                AggregateMemoryCache.CallbackRegistered[aggregateType] = true;
+            }
+
+            Monitor.Exit(AggregateMemoryCache.CallbackLock);
+        }
+
+        // Set the cache entry
+        this.MemoryCache.Set(key, aggregate, memoryCacheEntryOptions);
+        this.KeyTracker.TryAdd(key, aggregate);
+
+        Counter counterCalls = AggregateService.GetCounterMetric($"AggregateService_{aggregateType.Name}_times_cache_saved");
+        counterCalls.Inc();
+
+        Counter counterItems = AggregateService.GetCounterMetric($"AggregateService_{aggregateType.Name}_total_cached_items");
+        counterItems.IncTo(this.KeyTracker.Count);
+    }
+
+    public Boolean TryGetValueWithMetrics<TAggregate>(String key,
+                                                      out TAggregate aggregate) where TAggregate : Aggregate, new()
+    {
+        String g = typeof(TAggregate).Name;
+
+        var found = this.MemoryCache.TryGetValue(key, out aggregate);
+
+        if (!found)
+        {
+            //TODO: Failed cache hit?
+            Counter counterCalls = AggregateService.GetCounterMetric($"AggregateService_{g}_failed_cache_hit");
+            counterCalls.Inc();
+        }
+
+        return found;
+    }
+
+    public Boolean TryGetValue<TAggregate>(String key,
+                                           out TAggregate aggregate) where TAggregate : Aggregate, new()
+    {
+        return this.MemoryCache.TryGetValue(key, out aggregate);
+    }
+}

--- a/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
@@ -220,7 +220,6 @@ namespace TransactionProcessor.BusinessLogic.Services {
             String g = typeof(TAggregate).Name;
             String m = $"AggregateService";
             Counter counterCalls = AggregateService.GetCounterMetric($"{m}_{g}_times_saved");
-            Counter counterEvents = AggregateService.GetCounterMetric($"{m}_{g}_total_pending_events");
             Histogram histogramMetric = AggregateService.GetHistogramMetric($"{m}_{g}");
 
             counterCalls.Inc();

--- a/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
@@ -255,7 +255,7 @@ namespace TransactionProcessor.BusinessLogic.Services {
         public static readonly ConcurrentDictionary<String, Histogram> DynamicHistogram = new();
 
         private static readonly Func<String, String, String> FormatMetricName = (methodName,
-                                                                                 metricType) => $"eposity_{methodName}_{metricType}";
+                                                                                 metricType) => $"{methodName}_{metricType}";
 
         public static Histogram GetHistogramMetric(String methodName)
         {

--- a/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/AggregateService.cs
@@ -314,9 +314,7 @@ public class AggregateMemoryCache
             {
                 // Register a callback to remove the item from our internal tracking
                 memoryCacheEntryOptions.RegisterPostEvictionCallback((evictedKey,
-                                                                      evictedValue,
-                                                                      reason,
-                                                                      state) => {
+                                                                      _, _, _) => {
                                                                           this.KeyTracker.TryRemove(evictedKey.ToString(), out _);
                                                                       });
 

--- a/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
@@ -93,22 +93,22 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         private async Task<Result> ValidateEstate(Guid estateId, CancellationToken cancellationToken)
         {
-            EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+            Result<EstateAggregate> getEstateResult= await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
 
-            if (estateAggregate.IsCreated == false) {
-                return Result.Failure("Estate Is Not Created");
+            if (getEstateResult.IsFailed) {
+                return ResultHelpers.CreateFailure(getEstateResult);
             }
             return Result.Success();
         }
 
         private async Task<Result> ValidateContractProduct(Guid estateId, Guid contractId, Guid productId, CancellationToken cancellationToken)
         {
-            ContractAggregate contractAggregate = await this.AggregateService.Get<ContractAggregate>(contractId, cancellationToken);
-            if (contractAggregate.IsCreated == false)
+            Result<ContractAggregate> getContractResult = await this.AggregateService.Get<ContractAggregate>(contractId, cancellationToken);
+            if (getContractResult.IsFailed)
             {
-                return Result.Failure("Contract not created");
+                return ResultHelpers.CreateFailure(getContractResult);
             }
-
+            ContractAggregate contractAggregate = getContractResult.Data;
             Models.Contract.Contract contract = contractAggregate.GetContract();
             Boolean productExists = contract.Products.Any(cp => cp.ContractProductId == productId);
 

--- a/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
@@ -162,7 +162,6 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         public async Task<Result> RecordTransaction(FloatActivityCommands.RecordTransactionCommand command,
                                                     CancellationToken cancellationToken) {
-            //Result<TransactionAggregate> getTransactionResult = await this.TransactionAggregateRepository.GetLatestVersion(command.TransactionId, cancellationToken);
             Result<TransactionAggregate> getTransactionResult = await this.AggregateService.GetLatest<TransactionAggregate>(command.TransactionId, cancellationToken);
             if (getTransactionResult.IsFailed)
                 return ResultHelpers.CreateFailure(getTransactionResult);

--- a/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/FloatDomainService.cs
@@ -27,32 +27,18 @@ namespace TransactionProcessor.BusinessLogic.Services
     }
 
     public class FloatDomainService : IFloatDomainService{
-        private readonly IAggregateRepository<FloatAggregate, DomainEvent> FloatAggregateRepository;
-        private readonly IAggregateRepository<FloatActivityAggregate, DomainEvent> FloatActivityAggregateRepository;
-        private readonly IAggregateRepository<TransactionAggregate, DomainEvent> TransactionAggregateRepository;
-        private readonly IAggregateRepository<EstateAggregate, DomainEvent> EstateAggregateRepository;
-        private readonly IAggregateRepository<ContractAggregate, DomainEvent> ContractAggregateRepository;
+        private readonly IAggregateService AggregateService;
 
-        public FloatDomainService(IAggregateRepository<FloatAggregate, DomainEvent> floatAggregateRepository,
-                                  IAggregateRepository<FloatActivityAggregate, DomainEvent> floatActivityAggregateRepository,
-                                  IAggregateRepository<TransactionAggregate,DomainEvent> transactionAggregateRepository,
-                                  IAggregateRepository<EstateAggregate, DomainEvent> estateAggregateRepository,
-                                  IAggregateRepository<ContractAggregate, DomainEvent> contractAggregateRepository)
+        public FloatDomainService(IAggregateService aggregateService)
         {
-            this.FloatAggregateRepository = floatAggregateRepository;
-            this.FloatActivityAggregateRepository = floatActivityAggregateRepository;
-            this.TransactionAggregateRepository = transactionAggregateRepository;
-            this.EstateAggregateRepository = estateAggregateRepository;
-            this.ContractAggregateRepository = contractAggregateRepository;
+            this.AggregateService = aggregateService;
         }
-        
-        //private TokenResponse TokenResponse;
 
         private async Task<Result> ApplyFloatUpdates(Func<FloatAggregate, Result> action, Guid floatId, CancellationToken cancellationToken, Boolean isNotFoundError = true)
         {
             try
             {
-                Result<FloatAggregate> getFloatResult = await this.FloatAggregateRepository.GetLatestVersion(floatId, cancellationToken);
+                Result<FloatAggregate> getFloatResult = await this.AggregateService.GetLatest<FloatAggregate>(floatId, cancellationToken);
                 Result<FloatAggregate> floatAggregateResult = DomainServiceHelper.HandleGetAggregateResult(getFloatResult, floatId, isNotFoundError);
 
                 if (floatAggregateResult.IsFailed)
@@ -64,7 +50,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.FloatAggregateRepository.SaveChanges(floatAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(floatAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
 
@@ -80,7 +66,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<FloatActivityAggregate> getFloatResult = await this.FloatActivityAggregateRepository.GetLatestVersion(floatId, cancellationToken);
+                Result<FloatActivityAggregate> getFloatResult = await this.AggregateService.GetLatest<FloatActivityAggregate>(floatId, cancellationToken);
                 Result<FloatActivityAggregate> floatActivityAggregateResult = DomainServiceHelper.HandleGetAggregateResult(getFloatResult, floatId, isNotFoundError);
 
                 if (floatActivityAggregateResult.IsFailed)
@@ -92,7 +78,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.FloatActivityAggregateRepository.SaveChanges(floatActivityAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(floatActivityAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
 
@@ -107,23 +93,23 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         private async Task<Result> ValidateEstate(Guid estateId, CancellationToken cancellationToken)
         {
-            Result<EstateAggregate> result = await this.EstateAggregateRepository.GetLatestVersion(estateId, cancellationToken);
+            EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
 
-            if (result.IsFailed) {
-                return ResultHelpers.CreateFailure(result);
+            if (estateAggregate.IsCreated == false) {
+                return Result.Failure("Estate Is Not Created");
             }
             return Result.Success();
         }
 
         private async Task<Result> ValidateContractProduct(Guid estateId, Guid contractId, Guid productId, CancellationToken cancellationToken)
         {
-            Result<ContractAggregate> getContractResult = await this.ContractAggregateRepository.GetLatestVersion(contractId, cancellationToken);
-            if (getContractResult.IsFailed)
+            ContractAggregate contractAggregate = await this.AggregateService.Get<ContractAggregate>(contractId, cancellationToken);
+            if (contractAggregate.IsCreated == false)
             {
-                return ResultHelpers.CreateFailure(getContractResult);
+                return Result.Failure("Contract not created");
             }
 
-            Models.Contract.Contract contract = getContractResult.Data.GetContract();
+            Models.Contract.Contract contract = contractAggregate.GetContract();
             Boolean productExists = contract.Products.Any(cp => cp.ContractProductId == productId);
 
             return productExists switch {
@@ -176,7 +162,8 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         public async Task<Result> RecordTransaction(FloatActivityCommands.RecordTransactionCommand command,
                                                     CancellationToken cancellationToken) {
-            Result<TransactionAggregate> getTransactionResult = await this.TransactionAggregateRepository.GetLatestVersion(command.TransactionId, cancellationToken);
+            //Result<TransactionAggregate> getTransactionResult = await this.TransactionAggregateRepository.GetLatestVersion(command.TransactionId, cancellationToken);
+            Result<TransactionAggregate> getTransactionResult = await this.AggregateService.GetLatest<TransactionAggregate>(command.TransactionId, cancellationToken);
             if (getTransactionResult.IsFailed)
                 return ResultHelpers.CreateFailure(getTransactionResult);
 

--- a/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
@@ -72,10 +72,11 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
-                if (estateAggregate.IsCreated == false)
-                    return Result.Failure("Estate not created");
-                
+                Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+                if (getEstateResult.IsFailed) {
+                    return ResultHelpers.CreateFailure(getEstateResult);
+                }
+                EstateAggregate estateAggregate = getEstateResult.Data;
                 Result<MerchantAggregate> getMerchantResult = await this.AggregateService.GetLatest<MerchantAggregate>(merchantId, cancellationToken);
                 Result<MerchantAggregate> merchantAggregateResult =
                     DomainServiceHelper.HandleGetAggregateResult(getMerchantResult, merchantId, isNotFoundError);

--- a/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
@@ -397,12 +397,12 @@ namespace TransactionProcessor.BusinessLogic.Services
                     if (result.IsFailed)
                         return ResultHelpers.CreateFailure(result);
 
-                    ContractAggregate contractAggregate = await this.AggregateService.Get<ContractAggregate>(command.RequestDto.ContractId, cancellationToken);
-                    if (contractAggregate.IsCreated == false)
-                    {
-                        return Result.Failure("Contract not created");
+                    var getContractResult = await this.AggregateService.Get<ContractAggregate>(command.RequestDto.ContractId, cancellationToken);
+                    if (getContractResult.IsFailed) {
+                        return ResultHelpers.CreateFailure(getContractResult);
                     }
 
+                    ContractAggregate contractAggregate = getContractResult.Data;
                     if (contractAggregate.IsCreated == false)
                     {
                         return Result.Invalid($"Contract Id {command.RequestDto.ContractId} has not been created");

--- a/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
@@ -46,15 +46,8 @@ namespace TransactionProcessor.BusinessLogic.Services
     public class MerchantDomainService : IMerchantDomainService
     {
         #region Fields
-
-        private readonly IAggregateRepository<EstateAggregate, DomainEvent> EstateAggregateRepository;
-
-        private readonly IAggregateRepository<MerchantAggregate, DomainEvent> MerchantAggregateRepository;
-
-        private readonly IAggregateRepository<MerchantDepositListAggregate, DomainEvent> MerchantDepositListAggregateRepository;
-
-        private readonly IAggregateRepository<ContractAggregate, DomainEvent> ContractAggregateRepository;
-
+        
+        private readonly IAggregateService AggregateService;
         private readonly ISecurityServiceClient SecurityServiceClient;
         private readonly IEventStoreContext EventStoreContext;
 
@@ -62,17 +55,11 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         #region Constructors
 
-        public MerchantDomainService(IAggregateRepository<EstateAggregate, DomainEvent> estateAggregateRepository,
-                                     IAggregateRepository<MerchantAggregate, DomainEvent> merchantAggregateRepository,
-                                     IAggregateRepository<MerchantDepositListAggregate, DomainEvent> merchantDepositListAggregateRepository,
-                                     IAggregateRepository<ContractAggregate, DomainEvent> contractAggregateRepository,
+        public MerchantDomainService(IAggregateService aggregateService,
                                      ISecurityServiceClient securityServiceClient,
                                      IEventStoreContext eventStoreContext)
         {
-            this.EstateAggregateRepository = estateAggregateRepository;
-            this.MerchantAggregateRepository = merchantAggregateRepository;
-            this.MerchantDepositListAggregateRepository = merchantDepositListAggregateRepository;
-            this.ContractAggregateRepository = contractAggregateRepository;
+            this.AggregateService = aggregateService;
             this.SecurityServiceClient = securityServiceClient;
             this.EventStoreContext = eventStoreContext;
         }
@@ -85,12 +72,11 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> getEstateResult = await this.EstateAggregateRepository.GetLatestVersion(estateId, cancellationToken);
-                if (getEstateResult.IsFailed)
-                    return ResultHelpers.CreateFailure(getEstateResult);
-                EstateAggregate estateAggregate = getEstateResult.Data;
-
-                Result<MerchantAggregate> getMerchantResult = await this.MerchantAggregateRepository.GetLatestVersion(merchantId, cancellationToken);
+                EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+                if (estateAggregate.IsCreated == false)
+                    return Result.Failure("Estate not created");
+                
+                Result<MerchantAggregate> getMerchantResult = await this.AggregateService.GetLatest<MerchantAggregate>(merchantId, cancellationToken);
                 Result<MerchantAggregate> merchantAggregateResult =
                     DomainServiceHelper.HandleGetAggregateResult(getMerchantResult, merchantId, isNotFoundError);
                 if (merchantAggregateResult.IsFailed)
@@ -102,7 +88,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.MerchantAggregateRepository.SaveChanges(merchantAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(merchantAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
 
@@ -305,7 +291,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                     if (result.IsFailed)
                         return ResultHelpers.CreateFailure(result);
 
-                    Result<MerchantDepositListAggregate> getDepositListResult = await this.MerchantDepositListAggregateRepository.GetLatestVersion(command.MerchantId, cancellationToken);
+                    Result<MerchantDepositListAggregate> getDepositListResult = await this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, cancellationToken);
                     Result<MerchantDepositListAggregate> merchantDepositListAggregateResult =
                         DomainServiceHelper.HandleGetAggregateResult(getDepositListResult, command.MerchantId, false);
                     if (merchantDepositListAggregateResult.IsFailed)
@@ -325,7 +311,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                     };
                     merchantDepositListAggregate.MakeDeposit(depositSource, command.RequestDto.Reference, command.RequestDto.DepositDateTime, amount);
 
-                    Result saveResult = await this.MerchantDepositListAggregateRepository.SaveChanges(merchantDepositListAggregate, cancellationToken);
+                    Result saveResult = await this.AggregateService.Save(merchantDepositListAggregate, cancellationToken);
                     if (saveResult.IsFailed)
                         return ResultHelpers.CreateFailure(saveResult);
 
@@ -351,7 +337,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                     if (result.IsFailed)
                         return ResultHelpers.CreateFailure(result);
 
-                    Result<MerchantDepositListAggregate> getDepositListResult = await this.MerchantDepositListAggregateRepository.GetLatestVersion(command.MerchantId, cancellationToken);
+                    Result<MerchantDepositListAggregate> getDepositListResult = await this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, cancellationToken);
                     Result<MerchantDepositListAggregate> merchantDepositListAggregateResult =
                         DomainServiceHelper.HandleGetAggregateResult(getDepositListResult, command.MerchantId, false);
                     if (merchantDepositListAggregateResult.IsFailed)
@@ -382,6 +368,10 @@ namespace TransactionProcessor.BusinessLogic.Services
 
                     merchantDepositListAggregate.MakeWithdrawal(command.RequestDto.WithdrawalDateTime, amount);
 
+                    Result saveResult = await this.AggregateService.Save(merchantDepositListAggregate, cancellationToken);
+                    if (saveResult.IsFailed)
+                        return ResultHelpers.CreateFailure(saveResult);
+
                     return Result.Success();
                 }, command.EstateId, command.MerchantId, cancellationToken);
 
@@ -406,13 +396,12 @@ namespace TransactionProcessor.BusinessLogic.Services
                     if (result.IsFailed)
                         return ResultHelpers.CreateFailure(result);
 
-                    Result<ContractAggregate> getContractResult = await this.ContractAggregateRepository.GetLatestVersion(command.RequestDto.ContractId, cancellationToken);
-                    if (getContractResult.IsFailed)
+                    ContractAggregate contractAggregate = await this.AggregateService.Get<ContractAggregate>(command.RequestDto.ContractId, cancellationToken);
+                    if (contractAggregate.IsCreated == false)
                     {
-                        return ResultHelpers.CreateFailure(getContractResult);
+                        return Result.Failure("Contract not created");
                     }
 
-                    ContractAggregate contractAggregate = getContractResult.Data;
                     if (contractAggregate.IsCreated == false)
                     {
                         return Result.Invalid($"Contract Id {command.RequestDto.ContractId} has not been created");

--- a/TransactionProcessor.BusinessLogic/Services/OperatorDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/OperatorDomainService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Shared.DomainDrivenDesign.EventSourcing;
@@ -30,10 +31,11 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
-                if (estateAggregate.IsCreated == false)
-                    return Result.Failure("Estate not created");
-
+                Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+                if (getEstateResult.IsFailed) {
+                    return ResultHelpers.CreateFailure(getEstateResult);
+                }
+                EstateAggregate estateAggregate = getEstateResult.Data;
                 Result<OperatorAggregate> getOperatorResult = await this.AggregateService.GetLatest<OperatorAggregate>(operatorId, cancellationToken);
                 Result<OperatorAggregate> operatorAggregateResult =
                     DomainServiceHelper.HandleGetAggregateResult(getOperatorResult, operatorId, isNotFoundError);

--- a/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
@@ -64,67 +64,36 @@ namespace TransactionProcessor.BusinessLogic.Services{
     public class TransactionDomainService : ITransactionDomainService {
         #region Fields
 
-        /// <summary>
-        /// The operator proxy resolver
-        /// </summary>
+        private readonly IAggregateService AggregateService;
         private readonly Func<String, IOperatorProxy> OperatorProxyResolver;
-
-        /// <summary>
-        /// The reconciliation aggregate repository
-        /// </summary>
-        private readonly IAggregateRepository<ReconciliationAggregate, DomainEvent> ReconciliationAggregateRepository;
-
         private readonly ISecurityServiceClient SecurityServiceClient;
-        private readonly IAggregateRepository<OperatorAggregate, DomainEvent> OperatorAggregateRepository;
-        private readonly IAggregateRepository<FloatAggregate, DomainEvent> FloatAggregateRepository;
         private readonly IMemoryCacheWrapper MemoryCache;
         private readonly IFeeCalculationManager FeeCalculationManager;
         private readonly ITransactionReceiptBuilder TransactionReceiptBuilder;
         private readonly IMessagingServiceClient MessagingServiceClient;
-
         private TokenResponse TokenResponse;
-
-        private readonly IAggregateRepository<TransactionAggregate, DomainEvent> TransactionAggregateRepository;
-
         private readonly ITransactionValidationService TransactionValidationService;
-
-        private readonly IAggregateRepository<EstateAggregate, DomainEvent> EstateAggregateRepository;
-        private readonly IAggregateRepository<MerchantAggregate, DomainEvent> MerchantAggregateRepository;
-        private readonly IAggregateRepository<ContractAggregate, DomainEvent> ContractAggregateRepository;
-
+        
         #endregion
 
         #region Constructors
 
-        public TransactionDomainService(IAggregateRepository<TransactionAggregate, DomainEvent> transactionAggregateRepository,
+        public TransactionDomainService(IAggregateService aggregateService,
                                         Func<String, IOperatorProxy> operatorProxyResolver,
-                                        IAggregateRepository<ReconciliationAggregate, DomainEvent> reconciliationAggregateRepository,
                                         ITransactionValidationService transactionValidationService,
                                         ISecurityServiceClient securityServiceClient,
-                                        IAggregateRepository<FloatAggregate, DomainEvent> floatAggregateRepository,
                                         IMemoryCacheWrapper memoryCache,
                                         IFeeCalculationManager feeCalculationManager,
                                         ITransactionReceiptBuilder transactionReceiptBuilder,
-                                        IMessagingServiceClient messagingServiceClient,
-                                        IAggregateRepository<EstateAggregate, DomainEvent> estateAggregateRepository,
-                                        IAggregateRepository<OperatorAggregate, DomainEvent> operatorAggregateRepository,
-                                        IAggregateRepository<MerchantAggregate, DomainEvent> merchantAggregateRepository,
-                                        IAggregateRepository<ContractAggregate, DomainEvent> contractAggregateRepository) {
-            this.TransactionAggregateRepository = transactionAggregateRepository;
-            //this.EstateClient = estateClient;
+                                        IMessagingServiceClient messagingServiceClient) {
+            this.AggregateService = aggregateService;
             this.OperatorProxyResolver = operatorProxyResolver;
-            this.ReconciliationAggregateRepository = reconciliationAggregateRepository;
             this.TransactionValidationService = transactionValidationService;
             this.SecurityServiceClient = securityServiceClient;
-            this.FloatAggregateRepository = floatAggregateRepository;
             this.MemoryCache = memoryCache;
             this.FeeCalculationManager = feeCalculationManager;
             this.TransactionReceiptBuilder = transactionReceiptBuilder;
             this.MessagingServiceClient = messagingServiceClient;
-            EstateAggregateRepository = estateAggregateRepository;
-            this.OperatorAggregateRepository = operatorAggregateRepository;
-            MerchantAggregateRepository = merchantAggregateRepository;
-            this.ContractAggregateRepository = contractAggregateRepository;
         }
 
         #endregion
@@ -135,7 +104,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                       Boolean isNotFoundError = true) {
             try {
 
-                Result<TransactionAggregate> getTransactionResult = await this.TransactionAggregateRepository.GetLatestVersion(transactionId, cancellationToken);
+                Result<TransactionAggregate> getTransactionResult = await this.AggregateService.GetLatest<TransactionAggregate>(transactionId, cancellationToken);
                 Result<TransactionAggregate> transactionAggregateResult = DomainServiceHelper.HandleGetAggregateResult(getTransactionResult, transactionId, isNotFoundError);
 
                 if (transactionAggregateResult.IsFailed)
@@ -146,7 +115,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.TransactionAggregateRepository.SaveChanges(transactionAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(transactionAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
                 return Result.Success(result.Data);
@@ -162,7 +131,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                 Boolean isNotFoundError = true) {
             try {
 
-                Result<TransactionAggregate> getTransactionResult = await this.TransactionAggregateRepository.GetLatestVersion(transactionId, cancellationToken);
+                Result<TransactionAggregate> getTransactionResult = await this.AggregateService.GetLatest<TransactionAggregate>(transactionId, cancellationToken);
                 Result<TransactionAggregate> transactionAggregateResult = DomainServiceHelper.HandleGetAggregateResult(getTransactionResult, transactionId, isNotFoundError);
 
                 if (transactionAggregateResult.IsFailed)
@@ -173,7 +142,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.TransactionAggregateRepository.SaveChanges(transactionAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(transactionAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
                 return Result.Success();
@@ -189,7 +158,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                       Boolean isNotFoundError = true) {
             try {
 
-                Result<ReconciliationAggregate> getTransactionResult = await this.ReconciliationAggregateRepository.GetLatestVersion(transactionId, cancellationToken);
+                Result<ReconciliationAggregate> getTransactionResult = await this.AggregateService.GetLatest<ReconciliationAggregate>(transactionId, cancellationToken);
                 Result<ReconciliationAggregate> reconciliationAggregateResult = DomainServiceHelper.HandleGetAggregateResult(getTransactionResult, transactionId, isNotFoundError);
 
                 ReconciliationAggregate reconciliationAggregate = reconciliationAggregateResult.Data;
@@ -197,7 +166,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
 
-                Result saveResult = await this.ReconciliationAggregateRepository.SaveChanges(reconciliationAggregate, cancellationToken);
+                Result saveResult = await this.AggregateService.Save(reconciliationAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);
                 return Result.Success(result.Data);
@@ -302,12 +271,12 @@ namespace TransactionProcessor.BusinessLogic.Services{
                 Logger.LogInformation($"Validation response is [{JsonConvert.SerializeObject(validationResult)}]");
 
                 Guid floatAggregateId = IdGenerationService.GenerateFloatAggregateId(command.EstateId, command.ContractId, command.ProductId);
-                var floatAggregateResult = await this.FloatAggregateRepository.GetLatestVersion(floatAggregateId, cancellationToken);
+                Result<FloatAggregate> floatAggregateResult = await this.AggregateService.GetLatest<FloatAggregate>(floatAggregateId, cancellationToken);
                 Decimal unitCost = 0;
                 Decimal totalCost = 0;
                 if (floatAggregateResult.IsSuccess) {
                     // TODO: Move calculation to float
-                    var floatAggregate = floatAggregateResult.Data;
+                    FloatAggregate floatAggregate = floatAggregateResult.Data;
                     unitCost = floatAggregate.GetUnitCostPrice();
                     totalCost = transactionAmount.GetValueOrDefault() * unitCost;
                 }
@@ -491,7 +460,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                            CancellationToken cancellationToken) {
             this.TokenResponse = await Helpers.GetToken(this.TokenResponse, this.SecurityServiceClient, cancellationToken);
 
-            Result<TransactionAggregate> transactionAggregateResult = await this.TransactionAggregateRepository.GetLatestVersion(command.TransactionId, cancellationToken);
+            Result<TransactionAggregate> transactionAggregateResult = await this.AggregateService.GetLatest<TransactionAggregate>(command.TransactionId, cancellationToken);
 
             if (transactionAggregateResult.IsFailed)
                 return ResultHelpers.CreateFailure(transactionAggregateResult);
@@ -502,10 +471,10 @@ namespace TransactionProcessor.BusinessLogic.Services{
             if (merchantResult.IsFailed)
                 return ResultHelpers.CreateFailure(merchantResult);
 
-            Result<EstateAggregate> estateResult = await this.EstateAggregateRepository.GetLatestVersion(command.EstateId, cancellationToken);
-            if (estateResult.IsFailed)
-                return ResultHelpers.CreateFailure(estateResult);
-            Estate estate = estateResult.Data.GetEstate();
+            EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(command.EstateId, cancellationToken);
+            if (estateAggregate.IsCreated == false)
+                return Result.Failure("Estate is not created");
+            Estate estate = estateAggregate.GetEstate();
             Operator @operator = estate.Operators.Single(o => o.OperatorId == transaction.OperatorId);
 
             // Determine the body of the email
@@ -519,7 +488,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                              CancellationToken cancellationToken) {
             this.TokenResponse = await Helpers.GetToken(this.TokenResponse, this.SecurityServiceClient, cancellationToken);
 
-            Result<TransactionAggregate> transactionAggregateResult = await this.TransactionAggregateRepository.GetLatestVersion(command.TransactionId, cancellationToken);
+            Result<TransactionAggregate> transactionAggregateResult = await this.AggregateService.GetLatest<TransactionAggregate>(command.TransactionId, cancellationToken);
 
             if (transactionAggregateResult.IsFailed)
                 return ResultHelpers.CreateFailure(transactionAggregateResult);
@@ -617,9 +586,9 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                CancellationToken cancellationToken) {
             // TODO: Should this be firing a command to add the device??
             // Add the device to the merchant
-            Result<MerchantAggregate> merchantAggregate = await this.MerchantAggregateRepository.GetLatestVersion(merchantId, cancellationToken);
+            Result<MerchantAggregate> merchantAggregate = await this.AggregateService.GetLatest<MerchantAggregate>(merchantId, cancellationToken);
             merchantAggregate.Data.AddDevice(Guid.NewGuid(), deviceIdentifier);
-            await this.MerchantAggregateRepository.SaveChanges(merchantAggregate.Data, cancellationToken);
+            await this.AggregateService.Save(merchantAggregate.Data, cancellationToken);
         }
 
         /// <summary>
@@ -638,11 +607,11 @@ namespace TransactionProcessor.BusinessLogic.Services{
 
         private async Task<Result<Merchant>> GetMerchant(Guid merchantId,
                                                          CancellationToken cancellationToken) {
-            Result<MerchantAggregate> merchantAggregateResult = await this.MerchantAggregateRepository.GetLatestVersion(merchantId, cancellationToken);
+            MerchantAggregate merchantAggregate = await this.AggregateService.Get<MerchantAggregate>(merchantId, cancellationToken);
 
-            if (merchantAggregateResult.IsFailed)
-                return ResultHelpers.CreateFailure(merchantAggregateResult);
-            Merchant merchant = merchantAggregateResult.Data.GetMerchant();
+            if (merchantAggregate.IsCreated == false)
+                return Result.Failure("Merchant not created");
+            Merchant merchant = merchantAggregate.GetMerchant();
 
             return merchant;
         }
@@ -656,16 +625,16 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                                                 CancellationToken cancellationToken) {
 
             // TODO: introduce some kind of mapping in here to link operator id to the name
-            Result<EstateAggregate> estateResult = await this.EstateAggregateRepository.GetLatestVersion(merchant.EstateId, cancellationToken);
-            if (estateResult.IsFailed)
-                return ResultHelpers.CreateFailure(estateResult);
-            Estate estate = estateResult.Data.GetEstate();
+            EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(merchant.EstateId, cancellationToken);
+            if (estateAggregate.IsCreated == false)
+                return Result.Failure("Estate not created");
+            Estate estate = estateAggregate.GetEstate();
             Operator @operator = estate.Operators.SingleOrDefault(o => o.OperatorId == operatorId);
 
-            var operatorResult = await this.OperatorAggregateRepository.GetLatestVersion(operatorId, cancellationToken);
-            if (operatorResult.IsFailed)
-                return ResultHelpers.CreateFailure(operatorResult);
-            IOperatorProxy operatorProxy = this.OperatorProxyResolver(operatorResult.Data.Name.Replace(" ", ""));
+            OperatorAggregate operatorResult = await this.AggregateService.Get<OperatorAggregate>(operatorId, cancellationToken);
+            if (operatorResult.IsCreated == false)
+                return Result.Failure("Operator not created");
+            IOperatorProxy operatorProxy = this.OperatorProxyResolver(operatorResult.Name.Replace(" ", ""));
             try {
                 Result<OperatorResponse> saleResult = await operatorProxy.ProcessSaleMessage(transactionId, operatorId, merchant, transactionDateTime, transactionReference, additionalTransactionMetadata, cancellationToken);
                 if (saleResult.IsFailed) {
@@ -742,11 +711,11 @@ namespace TransactionProcessor.BusinessLogic.Services{
         private async Task<Result<List<Models.Contract.ContractProductTransactionFee>>> GetTransactionFeesForProduct(Guid contractId,
                                                                                                                      Guid productId,
                                                                                                                      CancellationToken cancellationToken) {
-            Result<ContractAggregate> contractAggregateResult = await this.ContractAggregateRepository.GetLatestVersion(contractId, CancellationToken.None);
-            if (contractAggregateResult.IsFailed)
-                return ResultHelpers.CreateFailure(contractAggregateResult);
+            ContractAggregate contractAggregateResult = await this.AggregateService.Get<ContractAggregate>(contractId, CancellationToken.None);
+            if (contractAggregateResult.IsCreated == false)
+                return Result.Failure("Contract not created");
 
-            Contract contract = contractAggregateResult.Data.GetContract();
+            Contract contract = contractAggregateResult.GetContract();
 
             Product product = contract.Products.SingleOrDefault(p => p.ContractProductId == productId);
             if (product == null)

--- a/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
@@ -628,18 +628,19 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                                                 CancellationToken cancellationToken) {
 
             // TODO: introduce some kind of mapping in here to link operator id to the name
-            Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(merchant.EstateId, cancellationToken);
-            if (getEstateResult.IsFailed)
-            {
-                return ResultHelpers.CreateFailure(getEstateResult);
-            }
-            EstateAggregate estateAggregate = getEstateResult.Data;
-            Models.Estate.Estate estate = estateAggregate.GetEstate();
-            Models.Estate.Operator @operator = estate.Operators.SingleOrDefault(o => o.OperatorId == operatorId);
+            //Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(merchant.EstateId, cancellationToken);
+            //if (getEstateResult.IsFailed)
+            //{
+            //    return ResultHelpers.CreateFailure(getEstateResult);
+            //}
+            //EstateAggregate estateAggregate = getEstateResult.Data;
+            //Models.Estate.Estate estate = estateAggregate.GetEstate();
+            //Models.Estate.Operator @operator = estate.Operators.SingleOrDefault(o => o.OperatorId == operatorId);
 
-            OperatorAggregate operatorResult = await this.AggregateService.Get<OperatorAggregate>(operatorId, cancellationToken);
-            if (operatorResult.IsCreated == false)
-                return Result.Failure("Operator not created");
+            Result<OperatorAggregate> getOperatorResult= await this.AggregateService.Get<OperatorAggregate>(operatorId, cancellationToken);
+            if (getOperatorResult.IsFailed)
+                return ResultHelpers.CreateFailure(getOperatorResult);
+            Models.Operator.Operator operatorResult = getOperatorResult.Data.GetOperator();
             IOperatorProxy operatorProxy = this.OperatorProxyResolver(operatorResult.Name.Replace(" ", ""));
             try {
                 Result<OperatorResponse> saleResult = await operatorProxy.ProcessSaleMessage(transactionId, operatorId, merchant, transactionDateTime, transactionReference, additionalTransactionMetadata, cancellationToken);

--- a/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
@@ -626,17 +626,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
                                                                                 Dictionary<String, String> additionalTransactionMetadata,
                                                                                 String transactionReference,
                                                                                 CancellationToken cancellationToken) {
-
-            // TODO: introduce some kind of mapping in here to link operator id to the name
-            //Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(merchant.EstateId, cancellationToken);
-            //if (getEstateResult.IsFailed)
-            //{
-            //    return ResultHelpers.CreateFailure(getEstateResult);
-            //}
-            //EstateAggregate estateAggregate = getEstateResult.Data;
-            //Models.Estate.Estate estate = estateAggregate.GetEstate();
-            //Models.Estate.Operator @operator = estate.Operators.SingleOrDefault(o => o.OperatorId == operatorId);
-
+            
             Result<OperatorAggregate> getOperatorResult= await this.AggregateService.Get<OperatorAggregate>(operatorId, cancellationToken);
             if (getOperatorResult.IsFailed)
                 return ResultHelpers.CreateFailure(getOperatorResult);

--- a/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
@@ -44,17 +44,14 @@ public interface ITransactionValidationService
 public class TransactionValidationService : ITransactionValidationService{
     #region Fields
     private readonly IEventStoreContext EventStoreContext;
-    private readonly IAggregateRepository<EstateAggregate, DomainEvent> EstateAggregateRepository;
-    private readonly IAggregateRepository<MerchantAggregate, DomainEvent> MerchantAggregateRepository;
+    private readonly IAggregateService AggregateService;
     #endregion
 
     public TransactionValidationService(IEventStoreContext eventStoreContext,
-                                        IAggregateRepository<EstateAggregate, DomainEvent> estateAggregateRepository,
-                                        IAggregateRepository<MerchantAggregate, DomainEvent> merchantAggregateRepository)
+                                        IAggregateService aggregateService)
     {
         this.EventStoreContext = eventStoreContext;
-        this.EstateAggregateRepository = estateAggregateRepository;
-        this.MerchantAggregateRepository = merchantAggregateRepository;
+        this.AggregateService = aggregateService;
     }
 
     #region Methods
@@ -164,7 +161,7 @@ public class TransactionValidationService : ITransactionValidationService{
 
     private async Task<Result<TransactionValidationResult<EstateAggregate>>> ValidateEstate(Guid estateId, CancellationToken cancellationToken)
     {
-        Result<EstateAggregate> getEstateResult = await this.EstateAggregateRepository.GetLatestVersion(estateId, cancellationToken);
+        var getEstateResult= await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
         if (getEstateResult.IsFailed) {
             TransactionValidationResult transactionValidationResult = getEstateResult.Status switch
             {
@@ -196,7 +193,7 @@ public class TransactionValidationService : ITransactionValidationService{
 
     private async Task<Result<TransactionValidationResult<MerchantAggregate>>> ValidateMerchant(Guid estateId, String estateName, Guid merchantId, CancellationToken cancellationToken)
     {
-        Result<MerchantAggregate> getMerchantResult = await this.MerchantAggregateRepository.GetLatestVersion(merchantId, cancellationToken);
+        Result<MerchantAggregate> getMerchantResult = await this.AggregateService.Get<MerchantAggregate>(merchantId, cancellationToken);
         if (getMerchantResult.IsFailed)
         {
             TransactionValidationResult transactionValidationResult = getMerchantResult.Status switch

--- a/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
@@ -199,9 +199,12 @@ public class VoucherDomainService : IVoucherDomainService
     private async Task<Result> ValidateVoucherIssue(Guid estateId, Guid operatorId, CancellationToken cancellationToken)
     {
         // Validate the Estate Record is a valid estate
-        EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
-        if (estateAggregate.IsCreated == false)
-            return Result.Failure("Estate not created");
+        Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+        if (getEstateResult.IsFailed)
+        {
+            return ResultHelpers.CreateFailure(getEstateResult);
+        }
+        EstateAggregate estateAggregate = getEstateResult.Data;
 
         Estate estate = estateAggregate.GetEstate();
         if (estate.Operators == null || estate.Operators.Any() == false)
@@ -221,9 +224,10 @@ public class VoucherDomainService : IVoucherDomainService
     private async Task<Result> ValidateVoucherRedemption(Guid estateId, CancellationToken cancellationToken)
     {
         // Validate the Estate Record is a valid estate
-        EstateAggregate estateAggregate = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
-        if (estateAggregate.IsCreated == false)
-            return Result.Failure("Estate not created");
+        Result<EstateAggregate> getEstateResult = await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+        if (getEstateResult.IsFailed) {
+            return ResultHelpers.CreateFailure(getEstateResult);
+        }
 
         return Result.Success();
     }

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
     <PackageReference Include="Shared.DomainDrivenDesign" Version="2025.4.2" />
     <PackageReference Include="Shared.EventStore" Version="2025.4.2" />

--- a/TransactionProcessor/Bootstrapper/RepositoryRegistry.cs
+++ b/TransactionProcessor/Bootstrapper/RepositoryRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Services;
 using TransactionProcessor.Database.Contexts;
 using TransactionProcessor.Repository;
 
@@ -64,7 +65,9 @@ namespace TransactionProcessor.Bootstrapper
             }
 
             this.AddTransient<IEventStoreContext, EventStoreContext>();
-            
+
+            this.AddSingleton<IAggregateService, AggregateService>();
+            this.AddSingleton<IAggregateRepositoryResolver, AggregateRepositoryResolver>();
             this.AddSingleton<IAggregateRepository<TransactionAggregate, DomainEvent>,
                 AggregateRepository<TransactionAggregate, DomainEvent>>();
             this.AddSingleton<IAggregateRepository<ReconciliationAggregate, DomainEvent>,
@@ -86,7 +89,7 @@ namespace TransactionProcessor.Bootstrapper
             this.AddSingleton<ITransactionProcessorReadRepository, TransactionProcessorReadRepository>();
             this.AddSingleton<ITransactionProcessorReadModelRepository, TransactionProcessorReadModelRepository>();
             this.AddSingleton<IProjection<MerchantBalanceState>, MerchantBalanceProjection>();
-
+            
             this.AddSingleton<IDbContextFactory<EstateManagementGenericContext>, DbContextFactory<EstateManagementGenericContext>>();
 
             this.AddSingleton<Func<String, EstateManagementGenericContext>>(cont => connectionString =>

--- a/TransactionProcessor/Startup.cs
+++ b/TransactionProcessor/Startup.cs
@@ -1,3 +1,5 @@
+using Prometheus;
+
 namespace TransactionProcessor
 {
     using System;
@@ -133,7 +135,8 @@ namespace TransactionProcessor
 
             app.UseAuthentication();
             app.UseAuthorization();
-
+            app.UseMetricServer(s => {
+            });
             app.UseEndpoints(endpoints => {
                                  endpoints.MapControllers();
                                  endpoints.MapHealthChecks("health",

--- a/TransactionProcessor/TransactionProcessor.csproj
+++ b/TransactionProcessor/TransactionProcessor.csproj
@@ -32,6 +32,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+	  <PackageReference Include="prometheus-net" Version="8.2.1" />
+	  <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
     <PackageReference Include="Shared" Version="2025.4.2" />
     <PackageReference Include="Shared.EventStore" Version="2025.4.2" />


### PR DESCRIPTION
- Updated FloatDomainServiceTests to utilize IAggregateService, simplifying test setup and reducing dependencies.
- Replaced multiple IAggregateRepository dependencies in FloatDomainService with a single IAggregateService for improved maintainability.
- Introduced IAggregateRepositoryResolver for dynamic repository resolution.
- Added AggregateService for aggregate retrieval, saving, and caching.
- Updated project file to include prometheus-net for metrics collection.
- Modified RepositoryRegistry to register new services for dependency injection.
- Enhanced Startup.cs to include Prometheus middleware for monitoring.
- Introduced AggregateMemoryCache for efficient aggregate caching.