### PR TITLE
Enhance SettlementAggregate tests and fee properties

### DIFF
--- a/TransactionProcessor.Aggregates.Tests/SettlementAggregateTests.cs
+++ b/TransactionProcessor.Aggregates.Tests/SettlementAggregateTests.cs
@@ -45,6 +45,18 @@ namespace TransactionProcessor.Aggregates.Tests
             
             aggregate.AggregateId.ShouldBe(TestData.SettlementAggregateId);
             aggregate.GetNumberOfFeesPendingSettlement().ShouldBe(1);
+            var fee = aggregate.GetFeesToBeSettled().SingleOrDefault();
+            fee.ShouldNotBe(default);
+            fee.merchantId.ShouldBe(TestData.MerchantId);
+            fee.transactionId.ShouldBe(TestData.TransactionId);
+            fee.calculatedFee.CalculatedValue.ShouldBe(TestData.CalculatedFeeMerchantFee().CalculatedValue);
+            fee.calculatedFee.FeeCalculationType.ShouldBe(TestData.CalculatedFeeMerchantFee().FeeCalculationType);
+            fee.calculatedFee.FeeId.ShouldBe(TestData.CalculatedFeeMerchantFee().FeeId);
+            fee.calculatedFee.FeeValue.ShouldBe(TestData.CalculatedFeeMerchantFee().FeeValue);
+            fee.calculatedFee.FeeType.ShouldBe(TestData.CalculatedFeeMerchantFee().FeeType);
+            fee.calculatedFee.FeeCalculatedDateTime.ShouldBe(TestData.CalculatedFeeMerchantFee().FeeCalculatedDateTime);
+            fee.calculatedFee.IsSettled.ShouldBe(TestData.CalculatedFeeMerchantFee().IsSettled);
+            fee.calculatedFee.SettlementDueDate.ShouldBe(TestData.CalculatedFeeMerchantFee().SettlementDueDate);
         }
         
         [Fact]

--- a/TransactionProcessor.Aggregates/SettlementAggregate.cs
+++ b/TransactionProcessor.Aggregates/SettlementAggregate.cs
@@ -230,7 +230,8 @@ namespace TransactionProcessor.Aggregates
                                                                   FeeId = domainEvent.FeeId,
                                                                   FeeType = FeeType.Merchant,
                                                                   FeeValue = domainEvent.FeeValue,
-                                                                  FeeCalculationType = (CalculationType)domainEvent.FeeCalculationType
+                                                                  FeeCalculationType = (CalculationType)domainEvent.FeeCalculationType,
+                                                                  FeeCalculatedDateTime = domainEvent.FeeCalculatedDateTime
                                                               }));
         }
 

--- a/TransactionProcessor.Testing/TestData.cs
+++ b/TransactionProcessor.Testing/TestData.cs
@@ -1570,7 +1570,10 @@ namespace TransactionProcessor.Testing
                 FeeCalculationType = CalculationType.Fixed,
                 FeeId = TestData.TransactionFeeId,
                 FeeValue = TestData.TransactionFeeValue,
-                FeeType = TransactionProcessor.Models.Contract.FeeType.Merchant
+                FeeType = TransactionProcessor.Models.Contract.FeeType.Merchant,
+                FeeCalculatedDateTime = TransactionFeeCalculateDateTime,
+                IsSettled = false,
+                SettlementDueDate = DateTime.MinValue
             };
 
         public static CalculatedFee CalculatedFeeMerchantFee(Guid transactionFeeId) =>


### PR DESCRIPTION
- Improved tests for `SettlementAggregate` to verify fee properties including `merchantId`, `transactionId`, and `calculatedFee` attributes.
- Updated `SettlementAggregate` to set `FeeCalculatedDateTime` during fee creation.
- Added new properties to `CalculatedFee` in `TestData` for better validation of fee state and timing.