### PR TITLE
Enhance save method to handle duplicates

### DIFF
--- a/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
+++ b/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
@@ -1851,7 +1851,7 @@ namespace TransactionProcessor.Repository {
 
             await context.FileLines.AddAsync(fileLine, cancellationToken);
 
-            return await context.SaveChangesAsync(cancellationToken);
+            return await context.SaveChangesWithDuplicateHandling(cancellationToken);
         }
 
         public async Task<Result> AddFileToImportLog(FileAddedToImportLogEvent domainEvent,


### PR DESCRIPTION
Updated the return statement in `ITransactionProcessorReadModelRepository.cs` to use `SaveChangesWithDuplicateHandling` instead of `SaveChangesAsync`. This change improves the handling of duplicate entries during the save operation.