### PR TITLE
Add transaction timing metrics and related updates

### DIFF
--- a/TransactionProcessor.Aggregates/TransactionAggregate.cs
+++ b/TransactionProcessor.Aggregates/TransactionAggregate.cs
@@ -277,6 +277,23 @@ namespace TransactionProcessor.Aggregates
             aggregate.ApplyAndAppend(transactionHasBeenCompletedEvent);
         }
 
+        public static void RecordTransactionTimings(this TransactionAggregate aggregate,
+                                                    DateTime TransactionStartedDateTime,
+                                                    DateTime? OperatorCommunicationsStartedEvent,
+                                                    DateTime? OperatorCommunicationsCompletedEvent,
+                                                    DateTime TransactionCompletedDateTime) {
+            TransactionDomainEvents.TransactionTimingsAddedToTransactionEvent transactionTimingsAddedToTransactionEvent =
+                new (aggregate.AggregateId,
+                     aggregate.EstateId,
+                     aggregate.MerchantId,
+                     TransactionStartedDateTime,
+                     OperatorCommunicationsStartedEvent,
+                     OperatorCommunicationsCompletedEvent,
+                     TransactionCompletedDateTime);
+
+            aggregate.ApplyAndAppend(transactionTimingsAddedToTransactionEvent);
+        }
+
         public static void RecordAdditionalRequestData(this TransactionAggregate aggregate, 
                                                        Guid operatorId,
                                                        Dictionary<String, String> additionalTransactionRequestMetadata)
@@ -660,6 +677,11 @@ namespace TransactionProcessor.Aggregates
                                              FeeValue = domainEvent.FeeValue,
                                              FeeCalculationType = (CalculationType)domainEvent.FeeCalculationType
                                          });
+        }
+
+        public static void PlayEvent(this TransactionAggregate aggregate,
+                                     TransactionDomainEvents.TransactionTimingsAddedToTransactionEvent domainEvent) {
+            // Nothing to do here, just a marker for the event
         }
     }
 

--- a/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
@@ -93,7 +93,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                 TestData.DeviceIdentifier,
                 TestData.TransactionTypeLogon.ToString(),
                 TestData.TransactionDateTime,
-                TestData.TransactionNumber);
+                TestData.TransactionNumber, TestData.TransactionReceivedDateTime);
             
             var result = await this.TransactionDomainService.ProcessLogonTransaction(command, CancellationToken.None);
             
@@ -122,7 +122,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                 TestData.DeviceIdentifier,
                 TestData.TransactionTypeLogon.ToString(),
                 TestData.TransactionDateTime,
-                TestData.TransactionNumber);
+                TestData.TransactionNumber, TestData.TransactionReceivedDateTime);
 
             var result = await this.TransactionDomainService.ProcessLogonTransaction(command, CancellationToken.None);
 
@@ -153,7 +153,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                 TestData.DeviceIdentifier,
                 TestData.TransactionTypeLogon.ToString(),
                 TestData.TransactionDateTime,
-                TestData.TransactionNumber);
+                TestData.TransactionNumber, TestData.TransactionReceivedDateTime);
 
             Result<ProcessLogonTransactionResponse> result = await this.TransactionDomainService.ProcessLogonTransaction(command, CancellationToken.None);
 
@@ -259,7 +259,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                     TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionTypeSale.ToString(),
                     TestData.TransactionDateTime, TestData.TransactionNumber, TestData.OperatorId,
                     TestData.CustomerEmailAddress, TestData.AdditionalTransactionMetaDataForMobileTopup(),
-                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource);
+                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource, TestData.TransactionReceivedDateTime);
             
             ProcessSaleTransactionResponse response = await this.TransactionDomainService.ProcessSaleTransaction(command, CancellationToken.None);
 
@@ -300,7 +300,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                     TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionTypeSale.ToString(),
                     TestData.TransactionDateTime, TestData.TransactionNumber, TestData.OperatorId,
                     TestData.CustomerEmailAddress, TestData.AdditionalTransactionMetaDataForMobileTopup(),
-                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource);
+                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource, TestData.TransactionReceivedDateTime);
 
             ProcessSaleTransactionResponse response = await this.TransactionDomainService.ProcessSaleTransaction(command, CancellationToken.None);
 
@@ -358,7 +358,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                     TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionTypeSale.ToString(),
                     TestData.TransactionDateTime, TestData.TransactionNumber, TestData.OperatorId,
                     TestData.CustomerEmailAddress, TestData.AdditionalTransactionMetaDataForMobileTopup(),
-                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource);
+                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource, TestData.TransactionReceivedDateTime);
 
             ProcessSaleTransactionResponse response = await this.TransactionDomainService.ProcessSaleTransaction(command, CancellationToken.None);
 
@@ -420,7 +420,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                     TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionTypeSale.ToString(),
                     TestData.TransactionDateTime, TestData.TransactionNumber, TestData.OperatorId,
                     TestData.CustomerEmailAddress, TestData.AdditionalTransactionMetaDataForMobileTopup(),
-                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource);
+                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource, TestData.TransactionReceivedDateTime);
 
             ProcessSaleTransactionResponse response = await this.TransactionDomainService.ProcessSaleTransaction(command, CancellationToken.None);
 
@@ -462,7 +462,7 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
                     TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionTypeSale.ToString(),
                     TestData.TransactionDateTime, TestData.TransactionNumber, TestData.OperatorId,
                     TestData.CustomerEmailAddress, TestData.AdditionalTransactionMetaDataForMobileTopup(),
-                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource);
+                    TestData.ContractId, TestData.ProductId, TestData.TransactionSource, TestData.TransactionReceivedDateTime);
 
             ProcessSaleTransactionResponse response = await this.TransactionDomainService.ProcessSaleTransaction(command, CancellationToken.None);
 

--- a/TransactionProcessor.BusinessLogic/EventHandling/ReadModelDomainEventHandler.cs
+++ b/TransactionProcessor.BusinessLogic/EventHandling/ReadModelDomainEventHandler.cs
@@ -71,6 +71,7 @@ namespace TransactionProcessor.BusinessLogic.EventHandling
                 TransactionDomainEvents.TransactionSourceAddedToTransactionEvent de => this.EstateReportingRepository.AddSourceDetailsToTransaction(de, cancellationToken),
                 TransactionDomainEvents.ProductDetailsAddedToTransactionEvent de => this.EstateReportingRepository.AddProductDetailsToTransaction(de, cancellationToken),
                 TransactionDomainEvents.TransactionHasBeenCompletedEvent de => this.EstateReportingRepository.CompleteTransaction(de, cancellationToken),
+                TransactionDomainEvents.TransactionTimingsAddedToTransactionEvent de => this.EstateReportingRepository.RecordTransactionTimings(de, cancellationToken),
                 ReconciliationDomainEvents.ReconciliationHasStartedEvent de => this.EstateReportingRepository.StartReconciliation(de, cancellationToken),
                 ReconciliationDomainEvents.OverallTotalsRecordedEvent de => this.EstateReportingRepository.UpdateReconciliationOverallTotals(de, cancellationToken),
                 ReconciliationDomainEvents.ReconciliationHasBeenLocallyAuthorisedEvent de => this.EstateReportingRepository.UpdateReconciliationStatus(de, cancellationToken),

--- a/TransactionProcessor.BusinessLogic/Requests/TransactionCommands.cs
+++ b/TransactionProcessor.BusinessLogic/Requests/TransactionCommands.cs
@@ -16,7 +16,8 @@ public record TransactionCommands {
                                                  String DeviceIdentifier,
                                                  String TransactionType,
                                                  DateTime TransactionDateTime,
-                                                 String TransactionNumber)
+                                                 String TransactionNumber,
+                                                 DateTime TransactionReceivedDateTime)
         : IRequest<Result<ProcessLogonTransactionResponse>>;
 
     public record ProcessReconciliationCommand(Guid TransactionId,
@@ -40,7 +41,8 @@ public record TransactionCommands {
                                                 Dictionary<String, String> AdditionalTransactionMetadata,
                                                 Guid ContractId,
                                                 Guid ProductId,
-                                                Int32 TransactionSource)
+                                                Int32 TransactionSource,
+                                                DateTime TransactionReceivedDateTime)
         : IRequest<Result<ProcessSaleTransactionResponse>>;
 
     public record ResendTransactionReceiptCommand(Guid TransactionId, Guid EstateId) : IRequest<Result>;

--- a/TransactionProcessor.Database/Contexts/EstateManagementGenericContext.cs
+++ b/TransactionProcessor.Database/Contexts/EstateManagementGenericContext.cs
@@ -112,6 +112,8 @@ public abstract class EstateManagementGenericContext : DbContext
     public DbSet<TodayTransaction> TodayTransactions { get; set; }
     public DbSet<TransactionHistory> TransactionHistory { get; set; }
 
+    public DbSet<TransactionTimings> TransactionTimings { get; set; }
+
     public DbSet<Event> Events { get; set; }
 
     #endregion
@@ -266,7 +268,8 @@ public abstract class EstateManagementGenericContext : DbContext
                     .SetupOperator()
                     .SetupSettlementSummary()
                     .SetupTransactionHistory()
-                    .SetupTodaysTransactions();
+                    .SetupTodaysTransactions()
+                    .SetupTransactionTimings();
         
         modelBuilder.SetupViewEntities();
 

--- a/TransactionProcessor.Database/Contexts/Extensions.cs
+++ b/TransactionProcessor.Database/Contexts/Extensions.cs
@@ -254,6 +254,14 @@ public static class Extensions{
         return modelBuilder;
     }
 
+    public static ModelBuilder SetupTransactionTimings(this ModelBuilder modelBuilder) {
+        modelBuilder.Entity<TransactionTimings>().HasKey(t => new {
+            t.TransactionId
+        }).IsClustered(false);
+
+        return modelBuilder;
+    }
+
     public static ModelBuilder SetupTransaction(this ModelBuilder modelBuilder){
         modelBuilder.Entity<Transaction>().HasKey(t => new {
                                                                t.TransactionReportingId,

--- a/TransactionProcessor.Database/Entities/TransactionTimings.cs
+++ b/TransactionProcessor.Database/Entities/TransactionTimings.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TransactionProcessor.Database.Entities;
+
+[Table("transactiontimings")]
+public class TransactionTimings {
+    public Guid TransactionId { get; set; }
+    public DateTime TransactionStartedDateTime { get; set; }
+    public DateTime? OperatorCommunicationsStartedDateTime { get; set; }
+    public DateTime? OperatorCommunicationsCompletedDateTime { get; set; }
+    public DateTime TransactionCompletedDateTime { get; set; }
+    public Double TotalTransactionInMilliseconds { get; set; }
+    public Double OperatorCommunicationsDurationInMilliseconds { get; set; }
+    public Double TransactionProcessingDurationInMilliseconds { get; set; }
+}

--- a/TransactionProcessor.Database/Migrations/MySql/20250505085317_LoadTransactionTimings.Designer.cs
+++ b/TransactionProcessor.Database/Migrations/MySql/20250505085317_LoadTransactionTimings.Designer.cs
@@ -3,48 +3,51 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TransactionProcessor.Database.Contexts;
 
 #nullable disable
 
-namespace EstateManagement.Database.Migrations.SqlServer
+namespace TransactionProcessor.Database.Migrations.MySql
 {
-    [DbContext(typeof(EstateManagementSqlServerContext))]
-    partial class EstateManagementSqlServerContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(EstateManagementMySqlContext))]
+    [Migration("20250505085317_LoadTransactionTimings")]
+    partial class LoadTransactionTimings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.14")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("TransactionProcessor.Database.Entities.Calendar", b =>
                 {
                     b.Property<DateTime>("Date")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("DayOfWeek")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DayOfWeekNumber")
                         .HasColumnType("int");
 
                     b.Property<string>("DayOfWeekShort")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MonthNameLong")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MonthNameShort")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("MonthNumber")
                         .HasColumnType("int");
@@ -54,14 +57,14 @@ namespace EstateManagement.Database.Migrations.SqlServer
 
                     b.Property<string>("WeekNumberString")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("Year")
                         .HasColumnType("int");
 
                     b.Property<string>("YearWeekNumber")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Date");
 
@@ -71,23 +74,23 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.Contract", b =>
                 {
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OperatorId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("ContractReportingId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ContractReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("ContractReportingId"));
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("EstateId", "OperatorId", "ContractId");
 
@@ -100,27 +103,27 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ContractProductReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("ContractProductReportingId"));
 
                     b.Property<Guid>("ContractId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("DisplayText")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ProductName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("ProductType")
                         .HasColumnType("int");
 
                     b.Property<decimal?>("Value")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.HasKey("ContractProductReportingId");
 
@@ -136,26 +139,26 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ContractProductTransactionFeeReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("ContractProductTransactionFeeReportingId"));
 
                     b.Property<int>("CalculationType")
                         .HasColumnType("int");
 
                     b.Property<Guid>("ContractProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractProductTransactionFeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("FeeType")
                         .HasColumnType("int");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<decimal>("Value")
                         .HasColumnType("decimal(18,4)");
@@ -174,20 +177,20 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("EstateReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("EstateReportingId"));
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Reference")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("EstateReportingId");
 
@@ -200,17 +203,17 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.EstateSecurityUser", b =>
                 {
                     b.Property<Guid>("SecurityUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("SecurityUserId", "EstateId");
 
@@ -223,38 +226,38 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("FileReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("FileReportingId"));
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("FileImportLogId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("FileLocation")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("FileProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("FileReceivedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("FileReceivedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("FileReportingId");
 
@@ -267,22 +270,22 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.FileImportLog", b =>
                 {
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("FileImportLogReportingId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("FileImportLogReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("FileImportLogReportingId"));
 
                     b.Property<Guid>("FileImportLogId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("ImportLogDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("ImportLogDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("EstateId", "FileImportLogReportingId");
 
@@ -295,33 +298,33 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.FileImportLogFile", b =>
                 {
                     b.Property<Guid>("FileImportLogId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("FilePath")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("FileProfileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("FileUploadedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("FileUploadedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("OriginalFileName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("FileImportLogId", "FileId");
 
@@ -331,25 +334,24 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.FileLine", b =>
                 {
                     b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("LineNumber")
                         .HasColumnType("int");
 
                     b.Property<string>("FileLineData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
-                    b.HasKey("FileId", "LineNumber");
-
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("FileId", "LineNumber"));
+                    b.HasKey("FileId", "LineNumber")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("fileline");
                 });
@@ -358,30 +360,28 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<Guid>("FloatId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
-                    b.HasKey("FloatId");
+                    b.HasKey("FloatId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("FloatId"), false);
-
-                    b.HasIndex("CreatedDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("CreatedDate"));
+                    b.HasIndex("CreatedDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("Floats");
                 });
@@ -390,34 +390,32 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<Guid>("EventId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("ActivityDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("ActivityDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<decimal>("Amount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("CostPrice")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<string>("CreditOrDebit")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("FloatId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
-                    b.HasKey("EventId");
+                    b.HasKey("EventId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("EventId"), false);
-
-                    b.HasIndex("ActivityDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("ActivityDate"));
+                    b.HasIndex("ActivityDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("FloatActivity");
                 });
@@ -428,32 +426,32 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("MerchantReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("MerchantReportingId"));
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("LastSaleDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("LastSaleDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("LastStatementGenerated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Reference")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("SettlementSchedule")
                         .HasColumnType("int");
@@ -469,38 +467,38 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantAddress", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("AddressId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("AddressLine1")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("AddressLine2")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("AddressLine3")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("AddressLine4")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Country")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("PostalCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Region")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Town")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("MerchantId", "AddressId");
 
@@ -510,23 +508,23 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantContact", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContactId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("EmailAddress")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("MerchantId", "ContactId");
 
@@ -536,13 +534,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantContract", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("MerchantId", "ContractId");
 
@@ -552,17 +550,17 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantDevice", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("DeviceId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("DeviceIdentifier")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("MerchantId", "DeviceId");
 
@@ -572,23 +570,23 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantOperator", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OperatorId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("MerchantNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TerminalNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("MerchantId", "OperatorId");
 
@@ -598,17 +596,17 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantSecurityUser", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("SecurityUserId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("CreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("MerchantId", "SecurityUserId");
 
@@ -618,28 +616,28 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.MerchantSettlementFee", b =>
                 {
                     b.Property<Guid>("SettlementId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractProductTransactionFeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<decimal>("CalculatedValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("FeeCalculatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<decimal>("FeeValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<bool>("IsSettled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.HasKey("SettlementId", "TransactionId", "ContractProductTransactionFeeId");
 
@@ -652,23 +650,23 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OperatorReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("OperatorReportingId"));
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("OperatorId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("RequireCustomMerchantNumber")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("RequireCustomTerminalNumber")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("OperatorReportingId");
 
@@ -684,25 +682,25 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("TransactionReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("TransactionReportingId"));
 
                     b.Property<string>("DeviceIdentifier")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IsAuthorised")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("ResponseCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessage")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("TransactionCount")
                         .HasColumnType("int");
@@ -711,29 +709,26 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("date");
 
                     b.Property<DateTime>("TransactionDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<TimeSpan>("TransactionTime")
-                        .HasColumnType("time");
+                        .HasColumnType("time(6)");
 
                     b.Property<decimal>("TransactionValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
-                    b.HasKey("TransactionReportingId");
+                    b.HasKey("TransactionReportingId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("TransactionReportingId"), false);
-
-                    b.HasIndex("TransactionDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionDate"));
+                    b.HasIndex("TransactionDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("TransactionId", "MerchantId")
-                        .IsUnique();
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionId", "MerchantId"), false);
+                        .IsUnique()
+                        .HasAnnotation("SqlServer:Clustered", false);
 
                     b.ToTable("reconciliation");
                 });
@@ -744,11 +739,11 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ResponseCode"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("ResponseCode"));
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("ResponseCode");
 
@@ -761,41 +756,38 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("SettlementReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("SettlementReportingId"));
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<bool>("ProcessingStarted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime>("ProcessingStartedDateTIme")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("SettlementDate")
                         .HasColumnType("date");
 
                     b.Property<Guid>("SettlementId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
-                    b.HasKey("SettlementReportingId");
+                    b.HasKey("SettlementReportingId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("SettlementReportingId"), false);
-
-                    b.HasIndex("SettlementDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("SettlementDate"));
+                    b.HasIndex("SettlementDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("EstateId", "SettlementId")
-                        .IsUnique();
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("EstateId", "SettlementId"), false);
+                        .IsUnique()
+                        .HasAnnotation("SqlServer:Clustered", false);
 
                     b.ToTable("settlement");
                 });
@@ -803,36 +795,34 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.StatementHeader", b =>
                 {
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("StatementId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("StatementCreatedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("StatementCreatedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("StatementGeneratedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("StatementGeneratedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("StatementReportingId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("StatementReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("StatementReportingId"));
 
-                    b.HasKey("MerchantId", "StatementId");
+                    b.HasKey("MerchantId", "StatementId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("MerchantId", "StatementId"), false);
-
-                    b.HasIndex("StatementGeneratedDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("StatementGeneratedDate"));
+                    b.HasIndex("StatementGeneratedDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("statementheader");
                 });
@@ -840,13 +830,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.StatementLine", b =>
                 {
                     b.Property<Guid>("StatementId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("ActivityDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("ActivityType")
                         .HasColumnType("int");
@@ -855,13 +845,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("date");
 
                     b.Property<string>("ActivityDescription")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<decimal>("InAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("OutAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.HasKey("StatementId", "TransactionId", "ActivityDateTime", "ActivityType");
 
@@ -877,13 +867,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("int");
 
                     b.Property<decimal?>("FeeValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsSettled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("MerchantReportingId")
                         .HasColumnType("int");
@@ -895,14 +885,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("int");
 
                     b.Property<decimal?>("SalesValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("SettlementDate")
                         .HasColumnType("date");
 
-                    b.HasIndex("SettlementDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("SettlementDate"));
+                    b.HasIndex("SettlementDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("SettlementDate", "MerchantReportingId", "OperatorReportingId", "ContractProductReportingId", "IsCompleted", "IsSettled")
                         .IsUnique();
@@ -914,7 +903,7 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<string>("AuthorisationCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("ContractProductReportingId")
                         .HasColumnType("int");
@@ -924,16 +913,16 @@ namespace EstateManagement.Database.Migrations.SqlServer
 
                     b.Property<string>("DeviceIdentifier")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("Hour")
                         .HasColumnType("int");
 
                     b.Property<bool>("IsAuthorised")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("MerchantReportingId")
                         .HasColumnType("int");
@@ -943,31 +932,31 @@ namespace EstateManagement.Database.Migrations.SqlServer
 
                     b.Property<string>("ResponseCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessage")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<decimal>("TransactionAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("TransactionDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("TransactionDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("TransactionNumber")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TransactionReference")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("TransactionReportingId")
                         .HasColumnType("int");
@@ -976,15 +965,14 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("int");
 
                     b.Property<TimeSpan>("TransactionTime")
-                        .HasColumnType("time");
+                        .HasColumnType("time(6)");
 
                     b.Property<string>("TransactionType")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
-                    b.HasIndex("TransactionDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionDate"));
+                    b.HasIndex("TransactionDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("TransactionId")
                         .IsUnique();
@@ -996,7 +984,7 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<string>("AuthorisationCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("ContractProductReportingId")
                         .HasColumnType("int");
@@ -1006,16 +994,16 @@ namespace EstateManagement.Database.Migrations.SqlServer
 
                     b.Property<string>("DeviceIdentifier")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("Hour")
                         .HasColumnType("int");
 
                     b.Property<bool>("IsAuthorised")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("MerchantReportingId")
                         .HasColumnType("int");
@@ -1025,31 +1013,31 @@ namespace EstateManagement.Database.Migrations.SqlServer
 
                     b.Property<string>("ResponseCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessage")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<decimal>("TransactionAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("TransactionDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("TransactionDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("TransactionNumber")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TransactionReference")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("TransactionReportingId")
                         .HasColumnType("int");
@@ -1058,15 +1046,14 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("int");
 
                     b.Property<TimeSpan>("TransactionTime")
-                        .HasColumnType("time");
+                        .HasColumnType("time(6)");
 
                     b.Property<string>("TransactionType")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
-                    b.HasIndex("TransactionDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionDate"));
+                    b.HasIndex("TransactionDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("TransactionId")
                         .IsUnique();
@@ -1080,77 +1067,74 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("TransactionReportingId"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("TransactionReportingId"));
 
                     b.Property<string>("AuthorisationCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("ContractId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("ContractProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("DeviceIdentifier")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IsAuthorised")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OperatorId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("ResponseCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessage")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<decimal>("TransactionAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("TransactionDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("TransactionDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("TransactionNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TransactionReference")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("TransactionSource")
                         .HasColumnType("int");
 
                     b.Property<TimeSpan>("TransactionTime")
-                        .HasColumnType("time");
+                        .HasColumnType("time(6)");
 
                     b.Property<string>("TransactionType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
-                    b.HasKey("TransactionReportingId");
+                    b.HasKey("TransactionReportingId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("TransactionReportingId"), false);
-
-                    b.HasIndex("TransactionDate");
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionDate"));
+                    b.HasIndex("TransactionDate")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.HasIndex("TransactionId")
-                        .IsUnique();
-
-                    SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("TransactionId"), false);
+                        .IsUnique()
+                        .HasAnnotation("SqlServer:Clustered", false);
 
                     b.ToTable("transaction");
                 });
@@ -1158,13 +1142,13 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.TransactionAdditionalRequestData", b =>
                 {
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Amount")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("CustomerAccountNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("TransactionId");
 
@@ -1174,7 +1158,7 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.Entities.TransactionAdditionalResponseData", b =>
                 {
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("TransactionReportingId")
                         .HasColumnType("int");
@@ -1188,32 +1172,31 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<Guid>("TransactionId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime?>("OperatorCommunicationsCompletedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<double>("OperatorCommunicationsDurationInMilliseconds")
-                        .HasColumnType("float");
+                        .HasColumnType("double");
 
                     b.Property<DateTime?>("OperatorCommunicationsStartedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<double>("TotalTransactionInMilliseconds")
-                        .HasColumnType("float");
+                        .HasColumnType("double");
 
                     b.Property<DateTime>("TransactionCompletedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<double>("TransactionProcessingDurationInMilliseconds")
-                        .HasColumnType("float");
+                        .HasColumnType("double");
 
                     b.Property<DateTime>("TransactionStartedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
-                    b.HasKey("TransactionId");
-
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("TransactionId"), false);
+                    b.HasKey("TransactionId")
+                        .HasAnnotation("SqlServer:Clustered", false);
 
                     b.ToTable("transactiontimings");
                 });
@@ -1222,72 +1205,71 @@ namespace EstateManagement.Database.Migrations.SqlServer
                 {
                     b.Property<Guid>("VoucherId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Barcode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<DateTime>("ExpiryDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("ExpiryDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("GenerateDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("GenerateDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("IsGenerated")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsIssued")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsRedeemed")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<DateTime>("IssuedDate")
                         .HasColumnType("date");
 
                     b.Property<DateTime>("IssuedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("OperatorIdentifier")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("RecipientEmail")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("RecipientMobile")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("RedeemedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("RedeemedDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
-                    b.Property<byte[]>("Timestamp")
+                    b.Property<DateTime>("Timestamp")
                         .IsConcurrencyToken()
-                        .IsRequired()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("rowversion");
+                        .HasColumnType("timestamp(6)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<decimal>("Value")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<string>("VoucherCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("VoucherId");
 
@@ -1301,54 +1283,54 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.Database.ViewEntities.SettlementView", b =>
                 {
                     b.Property<decimal>("Amount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("CalculatedValue")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<string>("DayOfWeek")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("FeeDescription")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IsCompleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsSettled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("MerchantName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Month")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("MonthNumber")
                         .HasColumnType("int");
 
                     b.Property<string>("OperatorIdentifier")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("SettlementDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("SettlementId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("TransactionId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("WeekNumber")
                         .HasColumnType("int");
@@ -1364,17 +1346,16 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.ProjectionEngine.Database.Database.Entities.Event", b =>
                 {
                     b.Property<Guid>("EventId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Type")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTime>("Date")
                         .HasColumnType("date");
 
-                    b.HasKey("EventId", "Type");
-
-                    SqlServerKeyBuilderExtensions.IsClustered(b.HasKey("EventId", "Type"));
+                    b.HasKey("EventId", "Type")
+                        .HasAnnotation("SqlServer:Clustered", true);
 
                     b.ToTable("Events");
                 });
@@ -1382,33 +1363,33 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.ProjectionEngine.Database.Database.Entities.MerchantBalanceChangedEntry", b =>
                 {
                     b.Property<Guid>("AggregateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OriginalEventId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("CauseOfChangeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<decimal>("ChangeAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<DateTime>("DateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("DebitOrCredit")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Reference")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("AggregateId", "OriginalEventId");
 
@@ -1418,25 +1399,25 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.ProjectionEngine.Database.Database.Entities.MerchantBalanceProjectionState", b =>
                 {
                     b.Property<Guid>("EstateId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<decimal>("AuthorisedSales")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("AvailableBalance")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("Balance")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<int>("CompletedTransactionCount")
                         .HasColumnType("int");
 
                     b.Property<decimal>("DeclinedSales")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<int>("DepositCount")
                         .HasColumnType("int");
@@ -1445,20 +1426,20 @@ namespace EstateManagement.Database.Migrations.SqlServer
                         .HasColumnType("int");
 
                     b.Property<DateTime>("LastDeposit")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("LastFee")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("LastSale")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime>("LastWithdrawal")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("MerchantName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("SaleCount")
                         .HasColumnType("int");
@@ -1466,20 +1447,19 @@ namespace EstateManagement.Database.Migrations.SqlServer
                     b.Property<int>("StartedTransactionCount")
                         .HasColumnType("int");
 
-                    b.Property<byte[]>("Timestamp")
+                    b.Property<DateTime>("Timestamp")
                         .IsConcurrencyToken()
-                        .IsRequired()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("rowversion");
+                        .HasColumnType("timestamp(6)");
 
                     b.Property<decimal>("TotalDeposited")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("TotalWithdrawn")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("ValueOfFees")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<int>("WithdrawalCount")
                         .HasColumnType("int");
@@ -1492,27 +1472,27 @@ namespace EstateManagement.Database.Migrations.SqlServer
             modelBuilder.Entity("TransactionProcessor.ProjectionEngine.Database.Database.ViewEntities.MerchantBalanceHistoryViewEntry", b =>
                 {
                     b.Property<decimal>("Balance")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<decimal>("ChangeAmount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("decimal(65,30)");
 
                     b.Property<string>("DebitOrCredit")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("EntryDateTime")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<Guid>("MerchantId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<Guid>("OriginalEventId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<string>("Reference")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.ToTable((string)null);
 

--- a/TransactionProcessor.Database/Migrations/MySql/20250505085317_LoadTransactionTimings.cs
+++ b/TransactionProcessor.Database/Migrations/MySql/20250505085317_LoadTransactionTimings.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TransactionProcessor.Database.Migrations.MySql
+{
+    /// <inheritdoc />
+    public partial class LoadTransactionTimings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "transactiontimings",
+                columns: table => new
+                {
+                    TransactionId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    TransactionStartedDateTime = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    OperatorCommunicationsStartedDateTime = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    OperatorCommunicationsCompletedDateTime = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    TransactionCompletedDateTime = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    TotalTransactionInMilliseconds = table.Column<double>(type: "double", nullable: false),
+                    OperatorCommunicationsDurationInMilliseconds = table.Column<double>(type: "double", nullable: false),
+                    TransactionProcessingDurationInMilliseconds = table.Column<double>(type: "double", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_transactiontimings", x => x.TransactionId);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "transactiontimings");
+        }
+    }
+}

--- a/TransactionProcessor.Database/Migrations/MySql/EstateManagementMySqlContextModelSnapshot.cs
+++ b/TransactionProcessor.Database/Migrations/MySql/EstateManagementMySqlContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace EstateManagement.Database.Migrations.MySql
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.3")
+                .HasAnnotation("ProductVersion", "8.0.14")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -1163,6 +1163,39 @@ namespace EstateManagement.Database.Migrations.MySql
                     b.HasKey("TransactionId");
 
                     b.ToTable("transactionadditionalresponsedata");
+                });
+
+            modelBuilder.Entity("TransactionProcessor.Database.Entities.TransactionTimings", b =>
+                {
+                    b.Property<Guid>("TransactionId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("char(36)");
+
+                    b.Property<DateTime?>("OperatorCommunicationsCompletedDateTime")
+                        .HasColumnType("datetime(6)");
+
+                    b.Property<double>("OperatorCommunicationsDurationInMilliseconds")
+                        .HasColumnType("double");
+
+                    b.Property<DateTime?>("OperatorCommunicationsStartedDateTime")
+                        .HasColumnType("datetime(6)");
+
+                    b.Property<double>("TotalTransactionInMilliseconds")
+                        .HasColumnType("double");
+
+                    b.Property<DateTime>("TransactionCompletedDateTime")
+                        .HasColumnType("datetime(6)");
+
+                    b.Property<double>("TransactionProcessingDurationInMilliseconds")
+                        .HasColumnType("double");
+
+                    b.Property<DateTime>("TransactionStartedDateTime")
+                        .HasColumnType("datetime(6)");
+
+                    b.HasKey("TransactionId")
+                        .HasAnnotation("SqlServer:Clustered", false);
+
+                    b.ToTable("transactiontimings");
                 });
 
             modelBuilder.Entity("TransactionProcessor.Database.Entities.VoucherProjectionState", b =>

--- a/TransactionProcessor.Database/Migrations/SqlServer/20250505085213_LoadTransactionTimings.Designer.cs
+++ b/TransactionProcessor.Database/Migrations/SqlServer/20250505085213_LoadTransactionTimings.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TransactionProcessor.Database.Contexts;
 
 #nullable disable
 
-namespace EstateManagement.Database.Migrations.SqlServer
+namespace TransactionProcessor.Database.Migrations.SqlServer
 {
     [DbContext(typeof(EstateManagementSqlServerContext))]
-    partial class EstateManagementSqlServerContextModelSnapshot : ModelSnapshot
+    [Migration("20250505085213_LoadTransactionTimings")]
+    partial class LoadTransactionTimings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TransactionProcessor.Database/Migrations/SqlServer/20250505085213_LoadTransactionTimings.cs
+++ b/TransactionProcessor.Database/Migrations/SqlServer/20250505085213_LoadTransactionTimings.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TransactionProcessor.Database.Migrations.SqlServer
+{
+    /// <inheritdoc />
+    public partial class LoadTransactionTimings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "transactiontimings",
+                columns: table => new
+                {
+                    TransactionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    TransactionStartedDateTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    OperatorCommunicationsStartedDateTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    OperatorCommunicationsCompletedDateTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    TransactionCompletedDateTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    TotalTransactionInMilliseconds = table.Column<double>(type: "float", nullable: false),
+                    OperatorCommunicationsDurationInMilliseconds = table.Column<double>(type: "float", nullable: false),
+                    TransactionProcessingDurationInMilliseconds = table.Column<double>(type: "float", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_transactiontimings", x => x.TransactionId)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "transactiontimings");
+        }
+    }
+}

--- a/TransactionProcessor.DomainEvents/TransactionDomainEvents.cs
+++ b/TransactionProcessor.DomainEvents/TransactionDomainEvents.cs
@@ -21,4 +21,7 @@ public class TransactionDomainEvents {
     public record TransactionHasBeenLocallyDeclinedEvent(Guid TransactionId, Guid EstateId, Guid MerchantId, String ResponseCode, String ResponseMessage, DateTime TransactionDateTime) : DomainEvent(TransactionId, Guid.NewGuid());
     public record TransactionHasStartedEvent(Guid TransactionId, Guid EstateId, Guid MerchantId, DateTime TransactionDateTime, String TransactionNumber, String TransactionType, String TransactionReference, String DeviceIdentifier, Decimal? TransactionAmount) : DomainEvent(TransactionId, Guid.NewGuid());
     public record TransactionSourceAddedToTransactionEvent(Guid TransactionId, Guid EstateId, Guid MerchantId, Int32 TransactionSource, DateTime TransactionDateTime) : DomainEvent(TransactionId, Guid.NewGuid());
+
+    public record TransactionTimingsAddedToTransactionEvent(Guid TransactionId, Guid EstateId, Guid MerchantId, DateTime TransactionStartedDateTime, DateTime? OperatorCommunicationsStartedEvent,
+                                                            DateTime? OperatorCommunicationsCompletedEvent, DateTime TransactionCompletedDateTime) : DomainEvent(TransactionId, Guid.NewGuid());
 }

--- a/TransactionProcessor.IntegrationTests/Features/SaleTransactionFeature.feature
+++ b/TransactionProcessor.IntegrationTests/Features/SaleTransactionFeature.feature
@@ -264,5 +264,3 @@ Scenario: Sale Transactions
 	Then transaction response should contain the following information
 	| EstateName    | MerchantName    | TransactionNumber | ResponseCode | ResponseMessage                                                                                                    |
 	| Test Estate 1 | Test Merchant 4 | 19                 | 1009         | Merchant [Test Merchant 4] does not have enough credit available [100.00] to perform transaction amount [300.00] |
-
-	

--- a/TransactionProcessor.Testing/TestData.cs
+++ b/TransactionProcessor.Testing/TestData.cs
@@ -408,6 +408,8 @@ namespace TransactionProcessor.Testing
 
         public static String TransactionNumber = "0001";
 
+        public static DateTime TransactionReceivedDateTime;
+
         public static TransactionType TransactionTypeLogon = TransactionType.Logon;
 
         public static String TransactionReference = "ABCDEFGHI";
@@ -2116,7 +2118,8 @@ namespace TransactionProcessor.Testing
                                                      TestData.AdditionalTransactionMetaDataForMobileTopup(),
                                                      TestData.ContractId,
                                                      TestData.ProductId,
-                                                     TestData.TransactionSource);
+                                                     TestData.TransactionSource,
+                                                     TestData.TransactionReceivedDateTime);
             public static TransactionCommands.ProcessReconciliationCommand ProcessReconciliationCommand =>
                 new(TestData.TransactionId, TestData.EstateId, TestData.MerchantId, TestData.DeviceIdentifier, TestData.TransactionDateTime, TestData.ReconciliationTransactionCount, TestData.ReconciliationTransactionValue);
             public static TransactionCommands.ProcessLogonTransactionCommand ProcessLogonTransactionCommand =>
@@ -2126,7 +2129,8 @@ namespace TransactionProcessor.Testing
                     TestData.DeviceIdentifier,
                     TestData.TransactionTypeLogon.ToString(),
                     TestData.TransactionDateTime,
-                    TestData.TransactionNumber);
+                    TestData.TransactionNumber,
+                    TestData.TransactionReceivedDateTime);
 
             public static SettlementCommands.ProcessSettlementCommand ProcessSettlementCommand =>
                 new(TestData.SettlementDate,

--- a/TransactionProcessor/appsettings.json
+++ b/TransactionProcessor/appsettings.json
@@ -41,6 +41,7 @@
         "TransactionFeeForProductAddedToContractEvent",
         "TransactionFeeForProductDisabledEvent",
         "TransactionHasBeenCompletedEvent",
+        "TransactionTimingsAddedToTransactionEvent",
         "SettledMerchantFeeAddedToTransactionEvent",
         "MerchantFeeSettledEvent",
         "TransactionCostInformationRecordedEvent",


### PR DESCRIPTION
- Implemented `RecordTransactionTimings` method in `TransactionAggregate` to log transaction timing metrics.
- Introduced `TransactionTimingsAddedToTransactionEvent` for encapsulating timing data.
- Updated `TransactionDomainService` to record timings during logon and sale processing.
- Modified `TransactionCommands` to include `TransactionReceivedDateTime`.
- Created `TransactionTimings` entity in the database for storing timing metrics.
- Added migration files for `transactiontimings` table in MySQL and SQL Server.
- Updated tests to validate new timing metrics and `TransactionReceivedDateTime`.
- Enhanced `ITransactionProcessorReadModelRepository` with a method for recording timings.
- Updated `TransactionController` to pass `transactionReceivedDateTime` in requests.
- Adjusted `EstateManagementGenericContext` setup methods for the new entity.
- Updated `appsettings.json` to include the new event type for transaction timings.

Fixes #773 