### PR TITLE
Enhance error handling in estate retrieval process

### DIFF
--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessorSteps.cs
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessorSteps.cs
@@ -995,12 +995,13 @@ public class TransactionProcessorSteps
         }
     }
 
-    public async Task WhenIGetTheEstateAnErrorIsReturned(String accessToken, String estateName, List<EstateDetails> estateDetailsList)
+    public async Task WhenIGetTheEstateAnErrorIsReturned(String accessToken, String estateName, List<EstateDetails> estateDetailsList, String errorStatus)
     {
         Guid estateId = Guid.NewGuid();
         Result<EstateResponse>? result = await this.TransactionProcessorClient.GetEstate(accessToken, estateId, CancellationToken.None).ConfigureAwait(false);
         result.IsSuccess.ShouldBeFalse();
-        result.Status.ShouldBe(ResultStatus.NotFound);
+        ResultStatus status = Enum.Parse<ResultStatus>(errorStatus);
+        result.Status.ShouldBe(status);
     }
 
     public async Task WhenIRemoveTheOperatorFromEstateTheOperatorIsRemoved(String accessToken, List<EstateDetails> estateDetailsList, String estateName, String operatorName)

--- a/TransactionProcessor.IntegrationTests/Features/Estate.feature
+++ b/TransactionProcessor.IntegrationTests/Features/Estate.feature
@@ -50,7 +50,7 @@ Scenario: Get Estate
 	| EmailAddress                  |
 	| estateuser1@testestate1.co.uk |
 	| estateuser2@testestate1.co.uk |
-	When I get the estate "Test Estate 2" an error is returned
+	When I get the estate "Test Estate 2" a "NotFound" error is returned
 	Given I am logged in as "estateuser1@testestate1.co.uk" with password "123456" for Estate "Test Estate 1" with client "estateClient"
 	When I get the estate "Test Estate 1" the estate details are returned as follows
 	| EstateName    |
@@ -63,7 +63,7 @@ Scenario: Get Estate
 	| EmailAddress                  |
 	| estateuser1@testestate1.co.uk |
 	| estateuser2@testestate1.co.uk |
-	When I get the estate "Test Estate 2" an error is returned
+	When I get the estate "Test Estate 2" a "Failure" error is returned
 
 Scenario: Update Estate
 	Given I have created the following estates

--- a/TransactionProcessor.IntegrationTests/Features/Estate.feature.cs
+++ b/TransactionProcessor.IntegrationTests/Features/Estate.feature.cs
@@ -259,7 +259,7 @@ await this.FeatureBackgroundAsync();
                         " follows", ((string)(null)), table36, "When ");
 #line hidden
 #line 53
- await testRunner.WhenAsync("I get the estate \"Test Estate 2\" an error is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+ await testRunner.WhenAsync("I get the estate \"Test Estate 2\" a \"NotFound\" error is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 54
  await testRunner.GivenAsync("I am logged in as \"estateuser1@testestate1.co.uk\" with password \"123456\" for Esta" +
@@ -293,7 +293,7 @@ await this.FeatureBackgroundAsync();
                         " follows", ((string)(null)), table39, "When ");
 #line hidden
 #line 66
- await testRunner.WhenAsync("I get the estate \"Test Estate 2\" an error is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+ await testRunner.WhenAsync("I get the estate \"Test Estate 2\" a \"Failure\" error is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/TransactionProcessor.IntegrationTests/Shared/SharedSteps.cs
+++ b/TransactionProcessor.IntegrationTests/Shared/SharedSteps.cs
@@ -467,11 +467,18 @@ namespace TransactionProcessor.IntegrationTests.Shared
             await this.TransactionProcessorSteps.WhenIGetTheEstateTheEstateSecurityUserDetailsAreReturnedAsFollows(this.TestingContext.AccessToken, estateName, this.TestingContext.Estates, securityUsers);
         }
 
-        [When(@"I get the estate ""(.*)"" an error is returned")]
-        public async Task WhenIGetTheEstateAnErrorIsReturned(String estateName)
+        //[When(@"I get the estate ""(.*)"" an error is returned")]
+        //public async Task WhenIGetTheEstateAnErrorIsReturned(String estateName)
+        //{
+        //    await this.TransactionProcessorSteps.WhenIGetTheEstateAnErrorIsReturned(this.TestingContext.AccessToken, estateName, this.TestingContext.Estates);
+        //}
+
+        [When("I get the estate {string} a {string} error is returned")]
+        public async Task WhenIGetTheEstateAErrorIsReturned(String estateName, string errorStatus)
         {
-            await this.TransactionProcessorSteps.WhenIGetTheEstateAnErrorIsReturned(this.TestingContext.AccessToken, estateName, this.TestingContext.Estates);
+            await this.TransactionProcessorSteps.WhenIGetTheEstateAnErrorIsReturned(this.TestingContext.AccessToken, estateName, this.TestingContext.Estates, errorStatus);
         }
+
 
         [Given(@"I am logged in as ""(.*)"" with password ""(.*)"" for Estate ""(.*)"" with client ""(.*)""")]
         public async Task GivenIAmLoggedInAsWithPasswordForEstate(String username,


### PR DESCRIPTION
- Updated `WhenIGetTheEstateAnErrorIsReturned` method in `TransactionProcessorSteps` to accept an `errorStatus` parameter for dynamic error handling.
- Modified `Estate.feature` scenarios to specify exact error types returned, improving clarity in test expectations.
- Adjusted `Estate.feature.cs` to align with updated feature scenarios, ensuring correct interpretation by the test runner.
- Refactored `SharedSteps.cs` to replace the old error handling method with a new one that accommodates the `errorStatus` parameter.
Fixes #807 