### PR TITLE
Add tests and functionality for MerchantStatementDomainService

### DIFF
--- a/TransactionProcessor.BusinessLogic/Services/MerchantStatementDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantStatementDomainService.cs
@@ -130,10 +130,6 @@ namespace TransactionProcessor.BusinessLogic.Services
             // Work out the next statement date
             DateTime nextStatementDate = CalculateStatementDate(command.SettledDateTime);
 
-            if (nextStatementDate.Year == 1) {
-                return Result.CriticalError($"Error in statement date generation Generated date is {nextStatementDate}");
-            }
-
             Guid merchantStatementId = IdGenerationService.GenerateMerchantStatementAggregateId(command.EstateId, command.MerchantId, nextStatementDate);
             Guid merchantStatementForDateId = IdGenerationService.GenerateMerchantStatementForDateAggregateId(command.EstateId, command.MerchantId, nextStatementDate, command.SettledDateTime);
             Guid settlementFeeId = GuidCalculator.Combine(command.TransactionId, command.SettledFeeId);
@@ -265,6 +261,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 var getTokenResult = await Helpers.GetToken(this.TokenResponse, this.SecurityServiceClient, cancellationToken);
                 if (getTokenResult.IsFailed)
                     return ResultHelpers.CreateFailure(getTokenResult);
+                this.TokenResponse = getTokenResult.Data;
 
                 var sendEmailResponseResult = await this.MessagingServiceClient.SendEmail(this.TokenResponse.AccessToken, sendEmailRequest, cancellationToken);
                 //if (sendEmailResponseResult.IsFailed) {
@@ -348,12 +345,7 @@ namespace TransactionProcessor.BusinessLogic.Services
 
             // Work out the next statement date
             DateTime nextStatementDate = CalculateStatementDate(command.TransactionDateTime);
-
-            if (nextStatementDate.Year == 1)
-            {
-                return Result.CriticalError($"Error in statement date generation Generated date is {nextStatementDate}");
-            }
-
+            
             Guid merchantStatementId = IdGenerationService.GenerateMerchantStatementAggregateId(command.EstateId, command.MerchantId, nextStatementDate);
             Guid merchantStatementForDateId = IdGenerationService.GenerateMerchantStatementForDateAggregateId(command.EstateId, command.MerchantId, nextStatementDate, command.TransactionDateTime);
 


### PR DESCRIPTION
- Introduced `MerchantStatementDomainServiceTests` with comprehensive tests for adding transactions, settled fees, recording activity dates, generating statements, and emailing statements.
- Updated `TestData.cs` with new command definitions and aggregate instances to support the new tests.
- Modified `MerchantStatementDomainService.cs` to include email sending logic and token retrieval, while simplifying statement date generation error handling.
- Updated `using` directives in relevant files to include necessary namespaces for new functionality.
Fixes #810 