### PR TITLE
Add DomainServiceHelper for aggregate fetching

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/Services/DomainServiceHelperTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/DomainServiceHelperTests.cs
@@ -3,6 +3,7 @@ using Shared.DomainDrivenDesign.EventSourcing;
 using Shared.EventStore.Aggregate;
 using Shouldly;
 using SimpleResults;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Services;
 using Xunit;
 

--- a/TransactionProcessor.BusinessLogic/Common/DomainServiceHelper.cs
+++ b/TransactionProcessor.BusinessLogic/Common/DomainServiceHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Shared.EventStore.Aggregate;
+using Shared.Results;
+using SimpleResults;
+
+namespace TransactionProcessor.BusinessLogic.Common;
+
+public static class DomainServiceHelper
+{
+    public static async Task<Result<TAggregate>> GetAggregateOrFailure<TAggregate>(Func<CancellationToken, Task<Result<TAggregate>>> fetchFunc,
+                                                                                   Guid aggregateId,
+                                                                                   CancellationToken cancellationToken,
+                                                                                   Boolean isNotFoundError = true) where TAggregate : Aggregate, new()
+    {
+        Result<TAggregate> result = await fetchFunc(cancellationToken);
+        return result.IsFailed switch
+        {
+            true => DomainServiceHelper.HandleGetAggregateResult(result, aggregateId, isNotFoundError),
+            _ => Result.Success(result.Data)
+        };
+    }
+
+    public static Result<T> HandleGetAggregateResult<T>(Result<T> result, Guid aggregateId, bool isNotFoundError = true)
+        where T : Aggregate, new()  // Constraint: T is a subclass of Aggregate and has a parameterless constructor
+    {
+        if (result.IsFailed && result.Status != ResultStatus.NotFound)
+        {
+            return ResultHelpers.CreateFailure(result);
+        }
+
+        if (result.Status == ResultStatus.NotFound && isNotFoundError)
+        {
+            return ResultHelpers.CreateFailure(result);
+        }
+
+        T aggregate = result.Status switch
+        {
+            ResultStatus.NotFound => new T { AggregateId = aggregateId },  // Set AggregateId when creating a new instance
+            _ => result.Data
+        };
+
+        return Result.Success(aggregate);
+    }
+}

--- a/TransactionProcessor.BusinessLogic/Services/ContractDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/ContractDomainService.cs
@@ -11,6 +11,7 @@ using Shared.Exceptions;
 using Shared.Results;
 using SimpleResults;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Requests;
 using TransactionProcessor.Models.Contract;
 

--- a/TransactionProcessor.BusinessLogic/Services/EstateDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/EstateDomainService.cs
@@ -12,6 +12,7 @@ using Shared.Exceptions;
 using Shared.Results;
 using SimpleResults;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Requests;
 
 namespace TransactionProcessor.BusinessLogic.Services

--- a/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using SecurityService.DataTransferObjects.Responses;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Requests;
 using TransactionProcessor.Database.Entities;
 using TransactionProcessor.Models.Estate;
@@ -71,21 +72,9 @@ namespace TransactionProcessor.BusinessLogic.Services
 
         #region Methods
 
-        //private async Task<Result<TAggregate>> GetAggregateOrFailure<TAggregate>(Func<CancellationToken, Task<Result<TAggregate>>> fetchFunc,
-        //                                                                         Guid aggregateId,
-        //                                                                         CancellationToken cancellationToken,
-        //                                                                         Boolean isNotFoundError = true) where TAggregate : Aggregate, new()
-        //{
-        //    Result<TAggregate> result = await fetchFunc(cancellationToken);
-        //    return result.IsFailed switch {
-        //        true => DomainServiceHelper.HandleGetAggregateResult(result, aggregateId, isNotFoundError),
-        //        _ => Result.Success(result.Data)
-        //    };
-        //}
-
         public async Task<Result> AddDeviceToMerchant(MerchantCommands.AddMerchantDeviceCommand command, CancellationToken cancellationToken) {
             try {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -294,7 +283,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -310,7 +299,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (validateResult.IsFailed)
                     return ResultHelpers.CreateFailure(validateResult);
 
-                Result<MerchantDepositListAggregate> getDepositListResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, ct), command.MerchantId, cancellationToken, false).ConfigureAwait(false);
+                Result<MerchantDepositListAggregate> getDepositListResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, ct), command.MerchantId, cancellationToken, false);
                 if (getDepositListResult.IsFailed)
                     return ResultHelpers.CreateFailure(getDepositListResult);
 
@@ -346,7 +335,7 @@ namespace TransactionProcessor.BusinessLogic.Services
 
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -362,7 +351,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (validateResult.IsFailed)
                     return ResultHelpers.CreateFailure(validateResult);
 
-                Result<MerchantDepositListAggregate> getDepositListResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, ct), command.MerchantId, cancellationToken).ConfigureAwait(false);
+                Result<MerchantDepositListAggregate> getDepositListResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<MerchantDepositListAggregate>(command.MerchantId, ct), command.MerchantId, cancellationToken);
                 if (getDepositListResult.IsFailed)
                     return ResultHelpers.CreateFailure(getDepositListResult);
                 
@@ -407,7 +396,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         public async Task<Result> AddContractToMerchant(MerchantCommands.AddMerchantContractCommand command, CancellationToken cancellationToken)
         {
             try {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -449,7 +438,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -486,7 +475,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -527,7 +516,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -569,7 +558,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -604,7 +593,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         public async Task<Result> UpdateMerchantContact(MerchantCommands.UpdateMerchantContactCommand command,
                                                         CancellationToken cancellationToken) {
             try {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -636,7 +625,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         public async Task<Result> RemoveOperatorFromMerchant(MerchantCommands.RemoveOperatorFromMerchantCommand command, CancellationToken cancellationToken)
         {
             try {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -668,7 +657,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -720,7 +709,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 

--- a/TransactionProcessor.BusinessLogic/Services/OperatorDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/OperatorDomainService.cs
@@ -8,6 +8,7 @@ using Shared.Exceptions;
 using Shared.Results;
 using SimpleResults;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.BusinessLogic.Requests;
 
 namespace TransactionProcessor.BusinessLogic.Services
@@ -30,7 +31,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         public async Task<Result> CreateOperator(OperatorCommands.CreateOperatorCommand command, CancellationToken cancellationToken)
         {
             try {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
@@ -66,7 +67,7 @@ namespace TransactionProcessor.BusinessLogic.Services
         {
             try
             {
-                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken).ConfigureAwait(false);
+                Result<EstateAggregate> estateResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<EstateAggregate>(command.EstateId, ct), command.EstateId, cancellationToken);
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 

--- a/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/VoucherDomainService.cs
@@ -1,5 +1,6 @@
 ﻿using Shared.Results;
 using TransactionProcessor.Aggregates;
+using TransactionProcessor.BusinessLogic.Common;
 using TransactionProcessor.Database.Contexts;
 using TransactionProcessor.DataTransferObjects.Responses.Estate;
 using TransactionProcessor.Models.Estate;


### PR DESCRIPTION
Introduced a new `DomainServiceHelper` class with methods `GetAggregateOrFailure` and `HandleGetAggregateResult` to streamline aggregate fetching and error handling. 
Updated multiple domain service files to utilize these methods, reducing code duplication and enhancing maintainability. 
New using directives for `TransactionProcessor.BusinessLogic.Common` were added to accommodate the helper class.

closes #852 