### PR TITLE
Refactor contract methods to remove ApplyUpdates

### DIFF
--- a/TransactionProcessor.BusinessLogic/Services/ContractDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/ContractDomainService.cs
@@ -160,7 +160,7 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (estateResult.IsFailed)
                     return ResultHelpers.CreateFailure(estateResult);
 
-                Result<ContractAggregate> contractResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<ContractAggregate>(command.ContractId, ct), command.ContractId, cancellationToken);
+                Result<ContractAggregate> contractResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<ContractAggregate>(command.ContractId, ct), command.ContractId, cancellationToken, false);
                 if (contractResult.IsFailed)
                     return ResultHelpers.CreateFailure(contractResult);
 


### PR DESCRIPTION
Removed the `ApplyUpdates` method and integrated its functionality directly into `AddProductToContract`, `AddTransactionFeeForProductToContract`, `DisableTransactionFeeForProduct`, and `CreateContract`. 
Refactored retrieval of `ContractAggregate` to use `DomainServiceHelper.GetAggregateOrFailure` for improved error handling. Updated checks for created aggregates to use newly retrieved instances. Added `try-catch` blocks for better exception management and ensured that changes are persisted with a save operation for `ContractAggregate`.

closes #851 