### PR TITLE
Enhance estate management with error handling and tests

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/Services/EstateDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/EstateDomainServiceTests.cs
@@ -45,6 +45,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services
         [Fact]
         public async Task EstateDomainService_AddOperatorEstate_OperatorIsAdded()
         {
+            this.AggregateService.Setup(m => m.Get<OperatorAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
+
             this.AggregateService.Setup(m => m.GetLatest<EstateAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(SimpleResults.Result.Success(TestData.Aggregates.CreatedEstateAggregate()));
             this.AggregateService.Setup(m => m.Save(It.IsAny<EstateAggregate>(), It.IsAny<CancellationToken>())).ReturnsAsync(SimpleResults.Result.Success());


### PR DESCRIPTION
- Updated `EstateDomainServiceTests.cs` to set up `AggregateService` for successful retrieval of `OperatorAggregate` and `EstateAggregate`.
- Added `CreateEstate` method in `EstateDomainService.cs` for creating estates with error handling.
- Removed `ApplyUpdates` method; integrated its functionality into `AddOperatorToEstate`.
- Modified `CreateEstateUser` to include error handling and user addition to the estate aggregate.
- Updated `RemoveOperatorFromEstate` to handle errors and ensure proper operator removal from estates.
closes #850 