### PR TITLE
Enhance error handling in transaction processing

### DIFF
--- a/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionValidationService.cs
@@ -161,7 +161,7 @@ public class TransactionValidationService : ITransactionValidationService{
 
     private async Task<Result<TransactionValidationResult<EstateAggregate>>> ValidateEstate(Guid estateId, CancellationToken cancellationToken)
     {
-        var getEstateResult= await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
+        Result<EstateAggregate> getEstateResult= await this.AggregateService.Get<EstateAggregate>(estateId, cancellationToken);
         if (getEstateResult.IsFailed) {
             TransactionValidationResult transactionValidationResult = getEstateResult.Status switch
             {


### PR DESCRIPTION
Refactor transaction processing methods to utilize the `DomainServiceHelper.GetAggregateOrFailure` for
consistent aggregate retrieval. 
Introduce try-catch blocks for improved exception management, ensuring graceful error handling and clearer failure messages. These changes enhance the robustness, maintainability, and readability of the code.

closes #857