### PR TITLE
Allow re-adding removed operators to EstateAggregate

### DIFF
--- a/TransactionProcessor.Aggregates.Tests/EstateAggregateTests.cs
+++ b/TransactionProcessor.Aggregates.Tests/EstateAggregateTests.cs
@@ -219,5 +219,27 @@ namespace TransactionProcessor.Aggregates.Tests
 
             result.Message.ShouldContain($"Operator not added to this Estate with Id [{TestData.OperatorId}]");
         }
+
+        [Fact]
+        public void EstateAggregate_RemoveOperatorFromEstate_ThenReAdd_OperatorAdded()
+        {
+            EstateAggregate aggregate = EstateAggregate.Create(TestData.EstateId);
+            aggregate.Create(TestData.EstateName);
+            aggregate.AddOperator(TestData.OperatorId);
+            
+            Estate estate = aggregate.GetEstate();
+            estate.Operators.ShouldHaveSingleItem();
+            estate.Operators.Single().IsDeleted.ShouldBeFalse();
+            aggregate.RemoveOperator(TestData.OperatorId);
+            
+            estate = aggregate.GetEstate();
+            estate.Operators.ShouldHaveSingleItem();
+            estate.Operators.Single().IsDeleted.ShouldBeTrue();
+            aggregate.AddOperator(TestData.OperatorId);
+
+            estate = aggregate.GetEstate();
+            estate.Operators.ShouldHaveSingleItem();
+            estate.Operators.Single().IsDeleted.ShouldBeFalse();
+        }
     }
 }


### PR DESCRIPTION
Updated operator addition logic to allow re-adding previously removed (deleted) operators by undeleting them instead of throwing a duplicate error. Modified event handling to support this behavior. Added a unit test to verify correct re-addition.

closes #1486 