### PR TITLE
Add float event tests and improve float creation handling

### DIFF
--- a/TransactionProcessor.DatabaseTests/ContractEventTests.cs
+++ b/TransactionProcessor.DatabaseTests/ContractEventTests.cs
@@ -11,8 +11,7 @@ using TransactionProcessor.Database.Entities;
 using TransactionProcessor.Repository;
 using TransactionProcessor.Testing;
 
-namespace TransactionProcessor.DatabaseTests
-{
+namespace TransactionProcessor.DatabaseTests {
     public class MerchantEventTests : BaseTest {
         [Fact]
         public async Task AddMerchant_MerchantIsAdded() {
@@ -49,8 +48,7 @@ namespace TransactionProcessor.DatabaseTests
         }
 
         [Fact]
-        public async Task SwapMerchantDevice_MerchantContractIsAdded()
-        {
+        public async Task SwapMerchantDevice_MerchantContractIsAdded() {
             Result result = await this.Repository.AddMerchantDevice(TestData.DomainEvents.DeviceAddedToMerchantEvent, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
             result = await this.Repository.SwapMerchantDevice(TestData.DomainEvents.DeviceSwappedForMerchantEvent, CancellationToken.None);
@@ -68,8 +66,7 @@ namespace TransactionProcessor.DatabaseTests
         }
 
         [Fact]
-        public async Task SwapMerchantDevice_EventReplayHandled()
-        {
+        public async Task SwapMerchantDevice_EventReplayHandled() {
             Result result = await this.Repository.AddMerchantDevice(TestData.DomainEvents.DeviceAddedToMerchantEvent, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
             result = await this.Repository.SwapMerchantDevice(TestData.DomainEvents.DeviceSwappedForMerchantEvent, CancellationToken.None);
@@ -97,6 +94,28 @@ namespace TransactionProcessor.DatabaseTests
             merchantDevice.ShouldNotBeNull();
             merchantDevice.DeviceIdentifier.ShouldBe(TestData.DomainEvents.DeviceSwappedForMerchantEvent.NewDeviceIdentifier);
             merchantDevice.IsEnabled.ShouldBeTrue();
+        }
+    }
+
+    public class FloatEventTests : BaseTest {
+        [Fact]
+        public async Task CreateFloat_FloatIsAdded()
+        {
+            Result result = await this.Repository.CreateFloat(TestData.DomainEvents.FloatCreatedForContractProductEvent, CancellationToken.None);
+            result.IsSuccess.ShouldBeTrue();
+            EstateManagementContext context = this.GetContext();
+            Float? @float = await context.Floats.SingleOrDefaultAsync(c => c.FloatId == TestData.DomainEvents.FloatCreatedForContractProductEvent.FloatId);
+            @float.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task CreateFloat_EventReplayHandled()
+        {
+            Result result = await this.Repository.CreateFloat(TestData.DomainEvents.FloatCreatedForContractProductEvent, CancellationToken.None);
+            result.IsSuccess.ShouldBeTrue();
+
+            result = await this.Repository.CreateFloat(TestData.DomainEvents.FloatCreatedForContractProductEvent, CancellationToken.None);
+            result.IsSuccess.ShouldBeTrue();
         }
     }
 

--- a/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
+++ b/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
@@ -1094,7 +1094,7 @@ namespace TransactionProcessor.Repository {
                 ProductId = domainEvent.ProductId
             };
             await context.Floats.AddAsync(floatRecord, cancellationToken);
-            return await context.SaveChangesAsync(cancellationToken);
+            return await context.SaveChangesWithDuplicateHandling(cancellationToken);
         }
 
         public async Task<Result> CreateFloatActivity(FloatDomainEvents.FloatCreditPurchasedEvent domainEvent,

--- a/TransactionProcessor.Testing/TestData.cs
+++ b/TransactionProcessor.Testing/TestData.cs
@@ -2587,7 +2587,7 @@ namespace TransactionProcessor.Testing
         public static String DepositAccountNumber = "12345678";
         public static Guid DepositHostIdentifier = Guid.Parse("1D1BD9F0-D953-4B2A-9969-98D3C0CDFA2A");
         public static String DepositSortCode = "112233";
-
+        
         public static Models.Merchant.Merchant MerchantModelWithAddressesContactsDevicesAndOperatorsAndContracts(Models.Merchant.SettlementSchedule settlementSchedule = Models.Merchant.SettlementSchedule.Immediate) =>
             new Models.Merchant.Merchant
             {
@@ -2627,7 +2627,7 @@ namespace TransactionProcessor.Testing
             };
 
         public static class DomainEvents {
-
+            public static FloatDomainEvents.FloatCreatedForContractProductEvent FloatCreatedForContractProductEvent => new FloatDomainEvents.FloatCreatedForContractProductEvent(FloatAggregateId, EstateId, ContractId, VariableContractProductId, FloatCreatedDateTime);
             public static TransactionDomainEvents.TransactionHasBeenCompletedEvent TransactionHasBeenCompletedEvent => new TransactionDomainEvents.TransactionHasBeenCompletedEvent(TestData.TransactionId,
                 TestData.EstateId,
                 TestData.MerchantId,


### PR DESCRIPTION
Introduce FloatEventTests for float creation and replay scenarios. Update repository to use SaveChangesWithDuplicateHandling for CreateFloat to handle duplicate events gracefully. Add test data for float events and make minor formatting improvements.

closes #1508 