### PR TITLE
Update dependencies and staging config IP addresses

### DIFF
--- a/TransactionProcessor.Aggregates.Tests/TransactionProcessor.Aggregates.Tests.csproj
+++ b/TransactionProcessor.Aggregates.Tests/TransactionProcessor.Aggregates.Tests.csproj
@@ -14,7 +14,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />

--- a/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
+++ b/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 	</ItemGroup>

--- a/TransactionProcessor.BusinessLogic.Tests/TransactionProcessor.BusinessLogic.Tests.csproj
+++ b/TransactionProcessor.BusinessLogic.Tests/TransactionProcessor.BusinessLogic.Tests.csproj
@@ -11,7 +11,7 @@
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -6,17 +6,17 @@
 
   <ItemGroup>
     <PackageReference Include="CallbackHandler.DataTransferObjects" Version="2025.12.4" />
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageReference Include="MessagingService.Client" Version="2025.12.1" />
+    <PackageReference Include="MessagingService.Client" Version="2026.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
     <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="32.2.5" />
+    <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="32.2.7" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />

--- a/TransactionProcessor.Client/TransactionProcessor.Client.csproj
+++ b/TransactionProcessor.Client/TransactionProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Database/TransactionProcessor.Database.csproj
+++ b/TransactionProcessor.Database/TransactionProcessor.Database.csproj
@@ -18,9 +18,9 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 	</ItemGroup>

--- a/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
+++ b/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
@@ -15,14 +15,14 @@
     </PackageReference>
 	  <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
 	  <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
+++ b/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.1" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
 	  <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
   </ItemGroup>

--- a/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
+++ b/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
     <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.12.2" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
 	  <PackageReference Include="NUnit" Version="4.5.0" />
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2025.12.1" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.1" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />

--- a/TransactionProcessor.ProjectionEngine.Tests/TransactionProcessor.ProjectionEngine.Tests.csproj
+++ b/TransactionProcessor.ProjectionEngine.Tests/TransactionProcessor.ProjectionEngine.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />

--- a/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
+++ b/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FileProcessor.File.DomainEvents" Version="2025.12.1" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2025.12.1" />
+    <PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.1" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
+++ b/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FileProcessor.File.DomainEvents" Version="2025.12.1" />
-		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2025.12.1" />
+		<PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.1" />
+		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 

--- a/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
+++ b/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2025.12.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />

--- a/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
+++ b/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />

--- a/TransactionProcessor/TransactionProcessor.csproj
+++ b/TransactionProcessor/TransactionProcessor.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
 	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
@@ -29,11 +29,11 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
 	  <PackageReference Include="prometheus-net" Version="8.2.1" />
 	  <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
       <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-      <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+      <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
 	  <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
 	  <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />

--- a/TransactionProcessor/appsettings.staging.json
+++ b/TransactionProcessor/appsettings.staging.json
@@ -1,10 +1,10 @@
 {
   "ConnectionStrings": {
-    "TransactionProcessorReadModel": "server=192.168.1.167;user id=sa;password=Sc0tland;database=TransactionProcessorReadModel;Encrypt=false"
+    "TransactionProcessorReadModel": "server=192.168.1.163;user id=sa;password=Sc0tland;database=TransactionProcessorReadModel;Encrypt=false"
   },
   "OperatorConfiguration": {
     "Safaricom": {
-      "Url": "http://192.168.1.167:9000/api/safaricom",
+      "Url": "http://192.168.1.163:9000/api/safaricom",
       "LoginId": "D-S136",
       "MSISDN": "700945625",
       "Pin": "0322",
@@ -12,7 +12,7 @@
       "ExtCode": "SA"
     },
     "PataPawaPostPay": {
-      "Url": "http://192.168.1.167:9000/PataPawaPostPayService/basichttp",
+      "Url": "http://192.168.1.163:9000/PataPawaPostPayService/basichttp",
       "Username": "testuser1",
       "Password": "password1",
       "ApiLogonRequired": true


### PR DESCRIPTION
Upgraded Microsoft.NET.Test.Sdk to 18.3.0 and updated multiple internal/shared NuGet packages to latest versions across the solution. Also updated Syncfusion.HtmlToPdfConverter.Net.Windows and several integration testing helpers. Changed appsettings.staging.json to use new server IP (192.168.1.163) for DB and operator URLs. No code logic changes included.

closes #1546 