### PR TITLE
Update dependencies to 2026.3.x and unify request logging

### DIFF
--- a/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
+++ b/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 	</ItemGroup>

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -6,15 +6,15 @@
 
   <ItemGroup>
     <PackageReference Include="CallbackHandler.DataTransferObjects" Version="2025.12.4" />
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageReference Include="MessagingService.Client" Version="2026.2.1" />
+    <PackageReference Include="MessagingService.Client" Version="2026.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="32.2.7" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />

--- a/TransactionProcessor.Client/TransactionProcessor.Client.csproj
+++ b/TransactionProcessor.Client/TransactionProcessor.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
-    <PackageReference Include="Shared.Results" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Database/TransactionProcessor.Database.csproj
+++ b/TransactionProcessor.Database/TransactionProcessor.Database.csproj
@@ -18,9 +18,9 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.2" />
+		<PackageReference Include="Shared" Version="2026.3.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 	</ItemGroup>

--- a/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
+++ b/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
+++ b/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
 	  <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
   </ItemGroup>

--- a/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
+++ b/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
 	  <PackageReference Include="NUnit" Version="4.5.0" />
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.2" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />

--- a/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
+++ b/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.1" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
+    <PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.2" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
+++ b/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.1" />
-		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
+		<PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.2" />
+		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.2" />
-		<PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+		<PackageReference Include="Shared" Version="2026.3.1" />
+		<PackageReference Include="Shared.EventStore" Version="2026.3.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 

--- a/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
+++ b/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />

--- a/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
+++ b/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />

--- a/TransactionProcessor/Startup.cs
+++ b/TransactionProcessor/Startup.cs
@@ -116,8 +116,7 @@ namespace TransactionProcessor
                 Logger.LogInformation($"Type name {type.Value} mapped to {type.Key.Name}");
             }
             app.UseMiddleware<TenantMiddleware>();
-            app.AddRequestLogging();
-            app.AddResponseLogging();
+            app.AddRequestResponseLogging();
             app.AddExceptionHandler();
 
             app.UseRouting();

--- a/TransactionProcessor/TransactionProcessor.csproj
+++ b/TransactionProcessor/TransactionProcessor.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
 	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
@@ -26,14 +26,14 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
 	  <PackageReference Include="prometheus-net" Version="8.2.1" />
 	  <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
       <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-      <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
+      <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
 	  <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
 	  <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />


### PR DESCRIPTION
Updated multiple NuGet package dependencies across all TransactionProcessor projects to 2026.3.x versions, including Shared libraries, ClientProxyBase, SecurityService.Client, MessagingService.Client, and FileProcessor domain events. Upgraded NLog.Extensions.Logging to 6.1.2. In Startup.cs, replaced separate request and response logging middleware with a unified AddRequestResponseLogging() call. No other functional changes included.

closes #1564 