### PR TITLE
Add exception handling to PataPawa logon methods

### DIFF
--- a/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPostPay/PataPawaPostPayProxy.cs
+++ b/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPostPay/PataPawaPostPayProxy.cs
@@ -42,32 +42,31 @@ namespace TransactionProcessor.BusinessLogic.OperatorInterfaces.PataPawaPostPay
         #region Methods
 
         public async Task<Result<OperatorResponse>> ProcessLogonMessage(CancellationToken cancellationToken) {
+            try {
+                // Check if we need to do a logon with the operator
+                OperatorResponse operatorResponse = this.MemoryCache.Get<OperatorResponse>("PataPawaPostPayLogon");
+                if (operatorResponse != null) {
+                    return operatorResponse;
+                }
 
-            // Check if we need to do a logon with the operator
-            OperatorResponse operatorResponse = this.MemoryCache.Get<OperatorResponse>("PataPawaPostPayLogon");
-            if (operatorResponse != null){
-                return operatorResponse;
+                IPataPawaPostPayService channel = this.ChannelResolver(this.ServiceClient, "PataPawaPostPay", this.Configuration.Url);
+                login logonResponse = await channel.getLoginRequestAsync(this.Configuration.Username, this.Configuration.Password);
+                if (logonResponse.status != 0) {
+                    return Result.Failure($"Error logging on with PataPawa Post Paid API, Response is {logonResponse.status}");
+                }
+
+                operatorResponse = new OperatorResponse { IsSuccessful = true, ResponseCode = "0000", ResponseMessage = logonResponse.message, AdditionalTransactionResponseMetadata = new Dictionary<String, String>() };
+
+                operatorResponse.AdditionalTransactionResponseMetadata.Add("PataPawaPostPaidAPIKey", logonResponse.api_key);
+                operatorResponse.AdditionalTransactionResponseMetadata.Add("PataPawaPostPaidBalance", logonResponse.balance.ToString());
+
+                this.MemoryCache.Set("PataPawaPostPayLogon", operatorResponse, MemoryCacheEntryOptions);
+
+                return Result.Success(operatorResponse);
             }
-
-            IPataPawaPostPayService channel = this.ChannelResolver(this.ServiceClient, "PataPawaPostPay", this.Configuration.Url);
-            login logonResponse = await channel.getLoginRequestAsync(this.Configuration.Username, this.Configuration.Password);
-            if (logonResponse.status != 0) {
-                return Result.Failure($"Error logging on with PataPawa Post Paid API, Response is {logonResponse.status}");
+            catch (Exception ex) {
+                return Result.Failure($"Error processing logon message for PataPawaPostPay [{ex.Message}]");
             }
-
-            operatorResponse = new OperatorResponse {
-                                                                         IsSuccessful = true,
-                                                                         ResponseCode = "0000",
-                                                                         ResponseMessage = logonResponse.message,
-                                                                         AdditionalTransactionResponseMetadata = new Dictionary<String, String>()
-                                                                     };
-
-            operatorResponse.AdditionalTransactionResponseMetadata.Add("PataPawaPostPaidAPIKey", logonResponse.api_key);
-            operatorResponse.AdditionalTransactionResponseMetadata.Add("PataPawaPostPaidBalance", logonResponse.balance.ToString());
-
-            this.MemoryCache.Set("PataPawaPostPayLogon", operatorResponse, MemoryCacheEntryOptions);
-
-            return Result.Success(operatorResponse);
         }
 
         private MemoryCacheEntryOptions MemoryCacheEntryOptions =>

--- a/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPrePay/PataPawaPrePayProxy.cs
+++ b/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPrePay/PataPawaPrePayProxy.cs
@@ -29,32 +29,37 @@ public class PataPawaPrePayProxy : IOperatorProxy{
     }
 
     public async Task<Result<OperatorResponse>> ProcessLogonMessage(CancellationToken cancellationToken){
-        // Check if we need to do a logon with the operator
-        OperatorResponse operatorResponse = this.MemoryCache.Get<OperatorResponse>("PataPawaPrePayLogon");
-        if (operatorResponse != null){
-            return Result.Success(operatorResponse);
+        try {
+            // Check if we need to do a logon with the operator
+            OperatorResponse operatorResponse = this.MemoryCache.Get<OperatorResponse>("PataPawaPrePayLogon");
+            if (operatorResponse != null) {
+                return Result.Success(operatorResponse);
+            }
+
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, this.Configuration.Url);
+            MultipartFormDataContent content = new MultipartFormDataContent();
+            content.Add(new StringContent("login"), "request");
+            content.Add(new StringContent(this.Configuration.Username), "username");
+            content.Add(new StringContent(this.Configuration.Password), "password");
+            requestMessage.Content = content;
+
+            HttpResponseMessage responseMessage = await this.HttpClient.SendAsync(requestMessage, cancellationToken);
+
+            // Check the send was successful
+            if (responseMessage.IsSuccessStatusCode == false) {
+                return Result.Failure($"Error sending logon request to Patapawa. Status Code [{responseMessage.StatusCode}]");
+            }
+
+            // Get the response
+            String responseContent = await responseMessage.Content.ReadAsStringAsync(cancellationToken);
+
+            Logger.LogInformation($"Received response message from Patapawa [{responseContent}]");
+
+            return this.CreateFromLogon(responseContent);
         }
-
-        HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, this.Configuration.Url);
-        MultipartFormDataContent content = new MultipartFormDataContent();
-        content.Add(new StringContent("login"), "request");
-        content.Add(new StringContent(this.Configuration.Username), "username");
-        content.Add(new StringContent(this.Configuration.Password), "password");
-        requestMessage.Content = content;
-
-        HttpResponseMessage responseMessage = await this.HttpClient.SendAsync(requestMessage, cancellationToken);
-
-        // Check the send was successful
-        if (responseMessage.IsSuccessStatusCode == false){
-            return Result.Failure($"Error sending logon request to Patapawa. Status Code [{responseMessage.StatusCode}]");
+        catch (Exception ex) {
+            return Result.Failure($"Error processing logon message for PataPawaPrePay [{ex.Message}]");
         }
-
-        // Get the response
-        String responseContent = await responseMessage.Content.ReadAsStringAsync(cancellationToken);
-
-        Logger.LogInformation($"Received response message from Patapawa [{responseContent}]");
-
-        return this.CreateFromLogon(responseContent);
     }
 
     public async Task<Result<OperatorResponse>> ProcessSaleMessage(Guid transactionId, Guid operatorId,

--- a/TransactionProcessor/Extensions.cs
+++ b/TransactionProcessor/Extensions.cs
@@ -218,7 +218,6 @@ namespace TransactionProcessor
         }
 
         private static void OperatorLogon(String operatorId) {
-            try {
                 Logger.LogInformation($"About to do auto logon for operator Id [{operatorId}]");
                 Func<String, IOperatorProxy> resolver = Startup.ServiceProvider.GetService<Func<String, IOperatorProxy>>();
                 IOperatorProxy proxy = resolver(operatorId);
@@ -232,11 +231,6 @@ namespace TransactionProcessor
                 if (logonResult.IsFailed) {
                     Logger.LogWarning($"Auto logon for operator Id [{operatorId}] status [{logonResult.Message}]");
                 }
-            }
-            catch (Exception ex) {
-                Logger.LogWarning($"Auto logon for operator Id [{operatorId}] failed.");
-                Logger.LogWarning(ex.ToString());
-            }
         }
     }
 }


### PR DESCRIPTION
Wrapped ProcessLogonMessage in PataPawaPostPayProxy and PataPawaPrePayProxy with try-catch blocks to return failure results on exceptions. Removed internal try-catch from OperatorLogon in Extensions.cs, allowing exceptions to propagate. This improves error reporting and centralizes exception handling.

closes #1550 