### PR TITLE
Change log level from Warning to Information

### DIFF
--- a/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/TransactionDomainService.cs
@@ -659,7 +659,7 @@ namespace TransactionProcessor.BusinessLogic.Services{
             DateTime? start = null, end = null;
 
             if (validationResult.Data.ResponseCode != TransactionResponseCode.Success) {
-                Logger.LogWarning($"Validation failed with ResponseCode {validationResult.Data.ResponseCode}: {validationResult.Data.ResponseMessage}");
+                Logger.LogInformation($"Validation failed with ResponseCode {validationResult.Data.ResponseCode}: {validationResult.Data.ResponseMessage}");
                 transactionAggregate.DeclineTransactionLocally(validationResult.Data.ResponseCode, validationResult.Data.ResponseMessage);
                 return (start, end);
             }

--- a/TransactionProcessor.Database/Contexts/EstateManagementGenericContext.cs
+++ b/TransactionProcessor.Database/Contexts/EstateManagementGenericContext.cs
@@ -375,7 +375,7 @@ ALTER DATABASE [{dbName}] SET MULTI_USER;
         catch (UniqueConstraintException uex)
         {
             // Swallow the error
-            Logger.LogWarning(BuildUniqueConstraintExceptionLogMessage(uex));
+            Logger.LogInformation(BuildUniqueConstraintExceptionLogMessage(uex));
             return Result.Success();
         }
     }

--- a/TransactionProcessor.ProjectionEngine/EventHandling/StateProjectionEventHandlers.cs
+++ b/TransactionProcessor.ProjectionEngine/EventHandling/StateProjectionEventHandlers.cs
@@ -35,11 +35,11 @@ public class StateProjectionEventHandler<TState> : IDomainEventHandler where TSt
             return await this.MigrateDatabase((EstateDomainEvents.EstateCreatedEvent)domainEvent, cancellationToken);
         }
 
-        Logger.LogWarning($"|{domainEvent.EventId}|State Projection Domain Event Handler - Inside Handle {domainEvent.EventType}");
+        Logger.LogInformation($"|{domainEvent.EventId}|State Projection Domain Event Handler - Inside Handle {domainEvent.EventType}");
         Stopwatch sw = Stopwatch.StartNew();
         Result result = await this.ProjectionHandler.Handle(domainEvent, cancellationToken);
         sw.Stop();
-        Logger.LogWarning($"|{domainEvent.EventId}|State Projection Event Handler - after Handle {domainEvent.EventType} time {sw.ElapsedMilliseconds}ms");
+        Logger.LogInformation($"|{domainEvent.EventId}|State Projection Event Handler - after Handle {domainEvent.EventType} time {sw.ElapsedMilliseconds}ms");
 
         return result;
     }

--- a/TransactionProcessor.ProjectionEngine/ProjectionHandler/ProjectionHandler.cs
+++ b/TransactionProcessor.ProjectionEngine/ProjectionHandler/ProjectionHandler.cs
@@ -89,7 +89,7 @@ public class ProjectionHandler<TState> : IProjectionHandler where TState : Share
 
         builder.Insert(0, $"Total time: {stopwatch.ElapsedMilliseconds}ms|");
 
-        Logger.LogWarning(builder.ToString());
+        Logger.LogInformation(builder.ToString());
         Logger.LogInformation($"{@event.EventId}|Event Type {@event.EventType} Id [{@event.EventId}] for state {state.GetType().Name} took {stopwatch.ElapsedMilliseconds}ms to process");
         
         return Result.Success();


### PR DESCRIPTION
Replaced all Logger.LogWarning calls with Logger.LogInformation in transaction validation, unique constraint handling, domain event processing, and projection logic to better reflect the informational nature of these log messages.

closes #1555 
closes #1556 
closes #1557 