### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/TransactionProcessor/Program.cs
+++ b/TransactionProcessor/Program.cs
@@ -87,7 +87,8 @@ namespace TransactionProcessor
                                                                      o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                      o.SendDefaultPii = true;
                                                                      o.MaxRequestBodySize = RequestSize.Always;
-                                                                     o.CaptureBlockingCalls = true;
+                                                                     o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                                                     o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                                                                      o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                                  });
                                                              }


### PR DESCRIPTION
CaptureBlockingCalls and IncludeActivityData are now set based on configuration values instead of hardcoded defaults, allowing for more flexible Sentry setup through external settings.

closes #1704 