### PR TITLE
Refactor web host config into ConfigureWebHost method

### DIFF
--- a/TransactionProcessor/Program.cs
+++ b/TransactionProcessor/Program.cs
@@ -28,14 +28,6 @@ namespace TransactionProcessor
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
-            //At this stage, we only need our hosting file for ip and ports
-            FileInfo fi = new FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
-
-            IConfigurationRoot config = new ConfigurationBuilder().SetBasePath(fi.Directory.FullName)
-                                                                  .AddJsonFile("hosting.json", optional: true)
-                                                                  .AddJsonFile("hosting.development.json", optional: true)
-                                                                  .AddEnvironmentVariables().Build();
-
             String contentRoot = Directory.GetCurrentDirectory();
             String nlogConfigPath = Path.Combine(contentRoot, "nlog.config");
 
@@ -53,52 +45,7 @@ namespace TransactionProcessor
             IHostBuilder hostBuilder = Host.CreateDefaultBuilder(args);
             hostBuilder.UseWindowsService();
             hostBuilder.UseLamar();
-            hostBuilder.ConfigureWebHostDefaults(webBuilder =>
-                                                 {
-                                                     webBuilder.ConfigureAppConfiguration((context, configBuilder) =>
-                                                     {
-                                                         var env = context.HostingEnvironment;
-
-                                                         configBuilder.SetBasePath(fi.Directory.FullName)
-                                                             .AddJsonFile("hosting.json", optional: true)
-                                                             .AddJsonFile($"hosting.{env.EnvironmentName}.json", optional: true)
-                                                             .AddJsonFile("/home/txnproc/config/appsettings.json", optional: true, reloadOnChange: true)
-                                                             .AddJsonFile($"/home/txnproc/config/appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
-                                                             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                                                             .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
-                                                             .AddEnvironmentVariables();
-
-                                                         // Build a snapshot of configuration so we can use it immediately (e.g. for Sentry)
-                                                         var builtConfig = configBuilder.Build();
-
-                                                         // Keep existing static usage (if you must), and initialise the ConfigurationReader now.
-                                                         Startup.Configuration = builtConfig;
-                                                         ConfigurationReader.Initialise(Startup.Configuration);
-
-                                                         // Configure Sentry on the webBuilder using the config snapshot.
-                                                         var sentrySection = builtConfig.GetSection("SentryConfiguration");
-                                                         if (sentrySection.Exists())
-                                                         {
-                                                             // Replace the condition below if you intended to only enable Sentry in certain environments.
-                                                             if (env.IsDevelopment() == false)
-                                                             {
-                                                                 webBuilder.UseSentry(o =>
-                                                                 {
-                                                                     o.Dsn = builtConfig["SentryConfiguration:Dsn"];
-                                                                     o.SendDefaultPii = true;
-                                                                     o.MaxRequestBodySize = RequestSize.Always;
-                                                                     o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
-                                                                     o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
-                                                                     o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
-                                                                 });
-                                                             }
-                                                         }
-                                                     });
-
-                                                     webBuilder.UseStartup<Startup>();
-                                                     webBuilder.UseConfiguration(config);
-                                                     webBuilder.UseKestrel();
-                                                 });
+            ConfigureWebHost(hostBuilder);
             hostBuilder.ConfigureLogging(logging => {
                 logging.AddConsole();
                 logging.AddNLog();
@@ -113,6 +60,56 @@ namespace TransactionProcessor
                                                                                                     });
                                           });
             return hostBuilder;
+        }
+
+        private static void ConfigureWebHost(IHostBuilder hostBuilder) {
+            hostBuilder.ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.ConfigureAppConfiguration((context, configBuilder) =>
+                {
+                    IWebHostEnvironment env = context.HostingEnvironment;
+
+                    FileInfo fi = new(Assembly.GetExecutingAssembly().Location);
+
+                    configBuilder.SetBasePath(fi.Directory.FullName)
+                        .AddJsonFile("hosting.json", optional: true)
+                        .AddJsonFile($"hosting.{env.EnvironmentName}.json", optional: true)
+                        .AddJsonFile("/home/txnproc/config/appsettings.json", optional: true, reloadOnChange: true)
+                        .AddJsonFile($"/home/txnproc/config/appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                        .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                        .AddEnvironmentVariables();
+
+                    // Build a snapshot of configuration so we can use it immediately (e.g. for Sentry)
+                    IConfigurationRoot builtConfig = configBuilder.Build();
+
+                    // Keep existing static usage (if you must), and initialise the ConfigurationReader now.
+                    Startup.Configuration = builtConfig;
+                    ConfigurationReader.Initialise(Startup.Configuration);
+
+                    // Configure Sentry on the webBuilder using the config snapshot.
+                    IConfigurationSection sentrySection = builtConfig.GetSection("SentryConfiguration");
+                    if (sentrySection.Exists())
+                    {
+                        // Replace the condition below if you intended to only enable Sentry in certain environments.
+                        if (env.IsDevelopment() == false)
+                        {
+                            webBuilder.UseSentry(o =>
+                            {
+                                o.Dsn = builtConfig["SentryConfiguration:Dsn"];
+                                o.SendDefaultPii = true;
+                                o.MaxRequestBodySize = RequestSize.Always;
+                                o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
+                                o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+                            });
+                        }
+                    }
+                });
+
+                webBuilder.UseStartup<Startup>();
+                webBuilder.UseKestrel();
+            });
         }
     }
 }


### PR DESCRIPTION
Extract web host configuration logic from CreateHostBuilder into a new private static ConfigureWebHost method in Program.cs. This improves code organization and readability without changing functionality. All configuration loading and Sentry setup logic is preserved in the new method.

closes #1701 