### PR TITLE
Remove obsolete TODOs and commented code; add AddFile method

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/Manager/TransactionProcessorManagerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Manager/TransactionProcessorManagerTests.cs
@@ -79,7 +79,6 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
             estateModel.Name.ShouldBe(TestData.EstateModel.Name);
             estateModel.Operators.ShouldHaveSingleItem();
             estateModel.Operators.Single().OperatorId.ShouldBe(TestData.OperatorId);
-            // TODO: add back in with operator aggregate
             estateModel.Operators.Single().Name.ShouldBe(TestData.OperatorName);
             estateModel.Operators.Single().IsDeleted.ShouldBeFalse();
         }

--- a/TransactionProcessor.BusinessLogic.Tests/Mediator/MediatorTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Mediator/MediatorTests.cs
@@ -43,9 +43,6 @@ namespace TransactionProcessor.BusinessLogic.Tests.Mediator
             this.Requests.Add(TestData.Commands.RecordTransactionCommand);
             this.Requests.Add(TestData.Commands.SendCustomerEmailReceiptCommand);
             this.Requests.Add(TestData.Commands.ResendTransactionReceiptCommand);
-            // TODO: this needs the query handling function refactoring to use a repository not the context direct
-            //this.Requests.Add(TestData.GetVoucherByVoucherCodeQuery);
-            //this.Requests.Add(TestData.GetVoucherByTransactionIdQuery);
 
             // Estate Commands and Queries
             this.Requests.Add(TestData.Commands.CreateEstateCommand);

--- a/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Services/TransactionDomainServiceTests.cs
@@ -505,7 +505,6 @@ namespace TransactionProcessor.BusinessLogic.Tests.Services{
             transactionAggregate.StartTransaction(TestData.TransactionDateTime, TestData.TransactionNumber, TransactionType.Sale, TestData.TransactionReference, new TransactionStartContext { EstateId = TestData.EstateId, MerchantId = TestData.MerchantId, DeviceIdentifier = TestData.DeviceIdentifier }, TestData.TransactionAmount);
             transactionAggregate.DeclineTransaction(TestData.OperatorId, "111", "SUCCESS", TransactionResponseCode.Success, "SUCCESS");
 
-            // TODO: maybe move this to an extension on aggregate
             var result = TransactionHelpers.RequireFeeCalculation(transactionAggregate);
             result.ShouldBeFalse();
         }

--- a/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantDomainService.cs
@@ -263,8 +263,6 @@ namespace TransactionProcessor.BusinessLogic.Services
                 if (stateResult.IsFailed)
                     return stateResult;
 
-                // TODO: add a delete user here in case the aggregate add fails...
-
                 Result saveResult = await this.AggregateService.Save(merchantAggregate, cancellationToken);
                 if (saveResult.IsFailed)
                     return ResultHelpers.CreateFailure(saveResult);

--- a/TransactionProcessor.BusinessLogic/Services/MerchantStatementDomainService.cs
+++ b/TransactionProcessor.BusinessLogic/Services/MerchantStatementDomainService.cs
@@ -258,50 +258,6 @@ namespace TransactionProcessor.BusinessLogic.Services
             return returnValue;
         }
 
-        /*public async Task<Result> BuildStatement(MerchantStatementCommands.BuildMerchantStatementCommand command,
-                                                 CancellationToken cancellationToken) {
-            try {
-                // Work out the next statement date
-                Result<MerchantStatementAggregate> getMerchantStatementResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.GetLatest<MerchantStatementAggregate>(command.MerchantStatementId, ct), command.MerchantStatementId, cancellationToken);
-                if (getMerchantStatementResult.IsFailed)
-                    return ResultHelpers.CreateFailure(getMerchantStatementResult);
-
-                MerchantStatementAggregate merchantStatementAggregate = getMerchantStatementResult.Data;
-                MerchantStatement statement = merchantStatementAggregate.GetStatement();
-                Result<MerchantAggregate> getMerchantResult = await DomainServiceHelper.GetAggregateOrFailure(ct => this.AggregateService.Get<MerchantAggregate>(statement.MerchantId, ct), statement.MerchantId, cancellationToken);
-                if (getMerchantResult.IsFailed)
-                    return ResultHelpers.CreateFailure(getMerchantResult);
-
-                if (getMerchantResult.Data.IsCreated == false)
-                    return Result.Invalid("Merchant must be created to build a statement");
-
-                Merchant merchantModel = getMerchantResult.Data.GetMerchant();
-
-                if (merchantModel.Addresses.Any()  == false)
-                    return Result.Invalid("Merchant must have an address to build a statement");
-
-                Result<String> htmlResult = await this.StatementBuilder.GetStatementHtml(merchantStatementAggregate, merchantModel, cancellationToken);
-                if (htmlResult.IsFailed)
-                    return ResultHelpers.CreateFailure(htmlResult);
-
-                // TODO: Record the html to the statement aggregate so we can use it later if needed
-                String base64 = EncodeTo64(htmlResult.Data);
-
-                Result stateResult = merchantStatementAggregate.BuildStatement(DateTime.Now, base64);
-                if (stateResult.IsFailed)
-                    return ResultHelpers.CreateFailure(stateResult);
-
-                Result saveResult = await this.AggregateService.Save(merchantStatementAggregate, cancellationToken);
-                if (saveResult.IsFailed)
-                    return ResultHelpers.CreateFailure(saveResult);
-
-                return Result.Success();
-            }
-            catch (Exception ex) {
-                return Result.Failure(ex.GetExceptionMessages());
-            }
-        }*/
-
         public async Task<Result> BuildStatement(MerchantStatementCommands.BuildMerchantStatementCommand command,
                                                  CancellationToken cancellationToken)
         {

--- a/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
+++ b/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
@@ -1874,39 +1874,6 @@ namespace TransactionProcessor.Repository {
             return await context.SaveChangesAsync(cancellationToken);
         }
 
-        // TODO@ Add this back in
-        //public async Task<Result> AddSettledFeeToStatement(SettledFeeAddedToStatementEvent domainEvent,
-        //                                                   CancellationToken cancellationToken)
-        //{
-        //    EstateManagementGenericContext context = await this.GetContextFromDomainEvent(domainEvent, cancellationToken);
-
-        //    // Find the corresponding transaction
-        //    var getTransactionResult = await context.LoadTransaction(domainEvent, cancellationToken);
-        //    if (getTransactionResult.IsFailed)
-        //        return ResultHelpers.CreateFailure(getTransactionResult);
-        //    var transaction = getTransactionResult.Data;
-
-        //    Result<Operator> operatorResult = await context.LoadOperator(transaction.OperatorId, cancellationToken);
-        //    if (operatorResult.IsFailed)
-        //        return ResultHelpers.CreateFailure(operatorResult);
-        //    var @operator = operatorResult.Data;
-
-        //    StatementLine line = new StatementLine
-        //    {
-        //        StatementId = domainEvent.MerchantStatementId,
-        //        ActivityDateTime = domainEvent.SettledDateTime,
-        //        ActivityDate = domainEvent.SettledDateTime.Date,
-        //        ActivityDescription = $"{@operator.Name} Transaction Fee",
-        //        ActivityType = 2, // Transaction Fee
-        //        TransactionId = domainEvent.TransactionId,
-        //        InAmount = domainEvent.SettledValue
-        //    };
-
-        //    await context.StatementLines.AddAsync(line, cancellationToken);
-
-        //    return await context.SaveChangesWithDuplicateHandling(cancellationToken);
-        //}
-
         public async Task<Result> CreateStatement(StatementCreatedEvent domainEvent,
                                                   CancellationToken cancellationToken)
         {
@@ -1924,41 +1891,7 @@ namespace TransactionProcessor.Repository {
 
             return await context.SaveChangesWithDuplicateHandling(cancellationToken);
         }
-
-        // TODO@ Add this back in
-        //public async Task<Result> AddTransactionToStatement(TransactionAddedToStatementEvent domainEvent,
-        //                                                    CancellationToken cancellationToken)
-        //{
-        //    EstateManagementGenericContext context = await this.GetContextFromDomainEvent(domainEvent, cancellationToken);
-
-        //    // Find the corresponding transaction
-        //    Result<Transaction> transactionResult = await context.LoadTransaction(domainEvent, cancellationToken);
-        //    if (transactionResult.IsFailed)
-        //        return ResultHelpers.CreateFailure(transactionResult);
-
-        //    Transaction transaction = transactionResult.Data;
-
-        //    Result<Operator> operatorResult = await context.LoadOperator(transaction.OperatorId, cancellationToken);
-        //    if (operatorResult.IsFailed)
-        //        return ResultHelpers.CreateFailure(operatorResult);
-        //    Operator @operator = operatorResult.Data;
-
-        //    StatementLine line = new StatementLine
-        //    {
-        //        StatementId = domainEvent.MerchantStatementId,
-        //        ActivityDateTime = domainEvent.TransactionDateTime,
-        //        ActivityDate = domainEvent.TransactionDateTime.Date,
-        //        ActivityDescription = $"{@operator.Name} Transaction",
-        //        ActivityType = 1, // Transaction
-        //        TransactionId = domainEvent.TransactionId,
-        //        OutAmount = domainEvent.TransactionValue
-        //    };
-
-        //    await context.StatementLines.AddAsync(line, cancellationToken);
-
-        //    return await context.SaveChangesWithDuplicateHandling(cancellationToken);
-        //}
-
+        
         public async Task<Result> AddFile(FileCreatedEvent domainEvent,
                               CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Clean up codebase by deleting outdated TODO comments and commented-out code from tests and services. Remove unused statement methods from repository. Add AddFile method to ITransactionProcessorReadModelRepository for handling FileCreatedEvent.

closes #1677 