### PR TITLE
Add UpdateMerchantSchedule method to client interface

### DIFF
--- a/TransactionProcessor.Client/ITransactionProcessorClient.cs
+++ b/TransactionProcessor.Client/ITransactionProcessorClient.cs
@@ -113,6 +113,13 @@ namespace TransactionProcessor.Client
                                             CreateMerchantScheduleRequest createMerchantScheduleRequest,
                                             CancellationToken cancellationToken);
 
+        Task<Result> UpdateMerchantSchedule(String accessToken,
+                                            Guid estateId,
+                                            Guid merchantId,
+                                            Int32 year,
+                                            UpdateMerchantScheduleRequest updateMerchantScheduleRequest,
+                                            CancellationToken cancellationToken);
+
         Task<Result<MerchantResponse>> GetMerchant(String accessToken,
                                                    Guid estateId,
                                                    Guid merchantId,

--- a/TransactionProcessor.Client/TransactionProcessorClient.cs
+++ b/TransactionProcessor.Client/TransactionProcessorClient.cs
@@ -762,17 +762,41 @@ public class TransactionProcessorClient : ClientProxyBase, ITransactionProcessor
             return Result.Success();
         }
         catch (Exception ex) {
-            Exception exception = new($"Error creating merchant schedule for merchant {merchantId} for estate {estateId}.", ex);
+            Exception exception = new($"Error creating schedule for merchant {merchantId} for estate {estateId}.", ex);
+
+            throw exception;
+        }
+    }
+
+    public async Task<Result> UpdateMerchantSchedule(String accessToken,
+                                                     Guid estateId,
+                                                     Guid merchantId,
+                                                     Int32 year,
+                                                     UpdateMerchantScheduleRequest updateMerchantScheduleRequest,
+                                                     CancellationToken cancellationToken) {
+        String requestUri = this.BuildRequestUrl($"/api/estates/{estateId}/merchants/{merchantId}/schedules/{year}");
+
+        try
+        {
+            var result = await this.SendHttpPatchRequest(requestUri, updateMerchantScheduleRequest, accessToken, cancellationToken);
+            if (result.IsFailed)
+                return ResultHelpers.CreateFailure(result);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            Exception exception = new($"Error updating {year} schedule for merchant {merchantId} for estate {estateId}.", ex);
 
             throw exception;
         }
     }
 
     public async Task<Result<MerchantScheduleResponse>> GetMerchantSchedule(String accessToken,
-                                                                             Guid estateId,
-                                                                             Guid merchantId,
-                                                                             Int32 year,
-                                                                             CancellationToken cancellationToken) {
+                                                                            Guid estateId,
+                                                                            Guid merchantId,
+                                                                            Int32 year,
+                                                                            CancellationToken cancellationToken) {
         String requestUri = this.BuildRequestUrl($"/api/estates/{estateId}/merchants/{merchantId}/schedules/{year}");
 
         try {


### PR DESCRIPTION
Introduced UpdateMerchantSchedule to ITransactionProcessorClient and its implementation, enabling merchant schedule updates via HTTP PATCH. Improved exception messages for schedule operations. No functional changes to GetMerchantSchedule.

closes #1727 