### PR TITLE
Use camelCase for MeterResponse deserialization

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/OperatorInterfaces/PataPawaPrePayProxyTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/OperatorInterfaces/PataPawaPrePayProxyTests.cs
@@ -134,7 +134,7 @@ public class PataPawaPrePayProxyTests {
 
         MeterResponse meterResponse = new MeterResponse { Status = -1, Code = "1", CustomerName = "Customer", Msg = "msg" };
 
-        this.MockHttpMessageHandler.When("http://localhost").Respond("application/json", StringSerialiser.Serialise(meterResponse));
+        this.MockHttpMessageHandler.When("http://localhost").Respond("application/json", StringSerialiser.Serialise(meterResponse, new SerialiserOptions(SerialiserPropertyFormat.CamelCase)));
 
         var result = await this.PataPawaPrePayProxy.ProcessSaleMessage(TestData.TransactionId,
             TestData.OperatorId, TestData.Merchant, TestData.TransactionDateTime, TestData.TransactionReference,

--- a/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPrePay/PataPawaPrePayProxy.cs
+++ b/TransactionProcessor.BusinessLogic/OperatorInterfaces/PataPawaPrePay/PataPawaPrePayProxy.cs
@@ -183,7 +183,7 @@ public class PataPawaPrePayProxy : IOperatorProxy{
 
     private Result<OperatorResponse> CreateFromMeter(String responseContent)
     {
-        MeterResponse meterResponse = StringSerialiser.Deserialise<MeterResponse>(responseContent);
+        MeterResponse meterResponse = StringSerialiser.Deserialise<MeterResponse>(responseContent, new SerialiserOptions(SerialiserPropertyFormat.CamelCase));
 
         if (meterResponse.Status != 0)
         {


### PR DESCRIPTION
Updated StringSerialiser.Deserialise to use SerialiserOptions with camelCase formatting when deserializing MeterResponse, ensuring correct mapping of JSON property names.