### PR TITLE
Centralize NuGet package versions with CPM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,104 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="CallbackHandler.DataTransferObjects" Version="2025.12.4" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+    <PackageVersion Include="EntityFrameworkCore.Exceptions.Common" Version="10.0.1" />
+    <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="10.0.1" />
+    <PackageVersion Include="EventStoreProjections" Version="2023.12.3" />
+    <PackageVersion Include="FileProcessor.File.DomainEvents" Version="2026.5.1" />
+    <PackageVersion Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.5.1" />
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="MessagingService.Client" Version="2026.5.1" />
+    <PackageVersion Include="MessagingService.IntegrationTesting.Helpers" Version="2026.5.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="10.7.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NetBarcode" Version="1.8.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.5.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="Polly" Version="8.7.0" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+    <PackageVersion Include="SecurityService.IntegrationTesting.Helpers" Version="2026.5.1" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="Shared.DomainDrivenDesign" Version="2026.5.7" />
+    <PackageVersion Include="Shared.EventStore" Version="2026.5.7" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="33.2.12" />
+    <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.ServiceModel.Duplex" Version="6.0.0" />
+    <PackageVersion Include="System.ServiceModel.Federation" Version="10.0.652802" />
+    <PackageVersion Include="System.ServiceModel.Http" Version="10.0.652802" />
+    <PackageVersion Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
+    <PackageVersion Include="System.ServiceModel.Security" Version="6.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'TransactionProcessor.ProjectionEngine.Database'">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="Shared" Version="2025.1.2" />
+    <PackageVersion Include="Shared.EventStore" Version="2025.1.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'TransactionProcessor.Reconciliation.DomainEvents'">
+    <PackageVersion Include="Shared.DomainDrivenDesign" Version="2025.1.2" />
+  </ItemGroup>
+</Project>

--- a/TransactionProcessor.Aggregates.Tests/TransactionProcessor.Aggregates.Tests.csproj
+++ b/TransactionProcessor.Aggregates.Tests/TransactionProcessor.Aggregates.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -10,26 +10,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+	  <PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
+++ b/TransactionProcessor.Aggregates/TransactionProcessor.Aggregates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="OpenTelemetry.Api" />
+		<PackageReference Include="Shared.EventStore" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantDomainEventHandlerTests.cs
@@ -17,7 +17,6 @@ using TransactionProcessor.DomainEvents;
 using TransactionProcessor.Repository;
 using TransactionProcessor.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers
 {

--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantStatementDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/MerchantStatementDomainEventHandlerTests.cs
@@ -12,7 +12,6 @@ using SimpleResults;
 using TransactionProcessor.BusinessLogic.EventHandling;
 using TransactionProcessor.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers;
 

--- a/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/TransactionDomainEventHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/DomainEventHandlers/TransactionDomainEventHandlerTests.cs
@@ -3,7 +3,6 @@ using Grpc.Core;
 using MediatR;
 using SimpleResults;
 using TransactionProcessor.DomainEvents;
-using Xunit.Abstractions;
 
 namespace TransactionProcessor.BusinessLogic.Tests.DomainEventHandlers
 {

--- a/TransactionProcessor.BusinessLogic.Tests/TransactionProcessor.BusinessLogic.Tests.csproj
+++ b/TransactionProcessor.BusinessLogic.Tests/TransactionProcessor.BusinessLogic.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -7,29 +7,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-	  <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-	  <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+	  <PackageReference Include="Lamar" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="RichardSzalay.MockHttp" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+	  <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+	  <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -1,35 +1,35 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CallbackHandler.DataTransferObjects" Version="2025.12.4" />
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageReference Include="MessagingService.Client" Version="2026.4.3-build125" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="Polly" Version="8.6.6" />
-    <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="33.2.7" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
-    <PackageReference Include="NetBarcode" Version="1.8.3" />
+    <PackageReference Include="CallbackHandler.DataTransferObjects" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="MessagingService.Client" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="prometheus-net" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="Shared.DomainDrivenDesign" />
+    <PackageReference Include="Shared.EventStore" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" />
+    <PackageReference Include="System.IO.Abstractions" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Duplex" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
+    <PackageReference Include="System.ServiceModel.Security" />
+    <PackageReference Include="NetBarcode" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Client/TransactionProcessor.Client.csproj
+++ b/TransactionProcessor.Client/TransactionProcessor.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFrameworks>net10.0</TargetFrameworks>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Shared.Results" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.DataTransferObjects/TransactionProcessor.DataTransferObjects.csproj
+++ b/TransactionProcessor.DataTransferObjects/TransactionProcessor.DataTransferObjects.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFrameworks>net10.0</TargetFrameworks>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Database/TransactionProcessor.Database.csproj
+++ b/TransactionProcessor.Database/TransactionProcessor.Database.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -8,22 +8,22 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="EntityFrameworkCore.Exceptions.Common" Version="10.0.0" />
-		<PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" Version="10.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+		<PackageReference Include="EntityFrameworkCore.Exceptions.Common" />
+		<PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
-		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="10.7.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TransactionProcessor.DatabaseTests/BaseTest.cs
+++ b/TransactionProcessor.DatabaseTests/BaseTest.cs
@@ -11,7 +11,6 @@ using Shared.Logger;
 using Shouldly;
 using TransactionProcessor.Database.Contexts;
 using TransactionProcessor.Repository;
-using Xunit.Abstractions;
 using Logger = Shared.Logger.Logger;
 
 namespace TransactionProcessor.DatabaseTests
@@ -20,7 +19,7 @@ namespace TransactionProcessor.DatabaseTests
     {
         protected ITransactionProcessorReadModelRepository Repository;
         protected ITestOutputHelper TestOutputHelper;
-        public virtual async Task InitializeAsync()
+        public virtual async ValueTask InitializeAsync()
         {
             Logger.Initialise(new Shared.Logger.NullLogger());
             
@@ -57,7 +56,7 @@ namespace TransactionProcessor.DatabaseTests
             this.Repository = new TransactionProcessorReadModelRepository(resolver.Object);
         }
 
-        public virtual async Task DisposeAsync() {
+        public virtual async ValueTask DisposeAsync() {
             await this.DockerHelper.StopContainersForScenarioRun(DockerServices.None);
         }
 

--- a/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
+++ b/TransactionProcessor.DatabaseTests/TransactionProcessor.DatabaseTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,24 +9,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 	  <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
-	  <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+	  <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
+	  <PackageReference Include="Shared.IntegrationTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
+++ b/TransactionProcessor.DomainEvents/TransactionProcessor.DomainEvents.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.6" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessor.IntegrationTesting.Helpers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
+    <PackageReference Include="ClientProxyBase" />
 	  <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Reqnroll" Version="3.3.4" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
+++ b/TransactionProcessor.IntegrationTests/TransactionProcessor.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -7,37 +7,37 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
+    <PackageReference Include="ClientProxyBase" />
     <!--<PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />-->
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build156" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
-	  <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Reqnroll" Version="3.3.4" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.4" />      
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="EventStoreProjections" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+	  <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />      
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.4.3-build125" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.ProjectionEngine.Database/TransactionProcessor.ProjectionEngine.Database.csproj
+++ b/TransactionProcessor.ProjectionEngine.Database/TransactionProcessor.ProjectionEngine.Database.csproj
@@ -7,14 +7,14 @@
 	<DebugType>None</DebugType>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
-		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-		<PackageReference Include="Shared" Version="2025.1.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
-		<PackageReference Include="Shared.EventStore" Version="2025.1.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Shared.EventStore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/TransactionProcessor.ProjectionEngine.Tests/TransactionProcessor.ProjectionEngine.Tests.csproj
+++ b/TransactionProcessor.ProjectionEngine.Tests/TransactionProcessor.ProjectionEngine.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -9,21 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	  <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+	  <PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
+++ b/TransactionProcessor.ProjectionEngine/TransactionProcessor.ProjectionEngine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.2" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
+    <PackageReference Include="FileProcessor.File.DomainEvents" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.EventStore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Reconciliation.DomainEvents/TransactionProcessor.Reconciliation.DomainEvents.csproj
+++ b/TransactionProcessor.Reconciliation.DomainEvents/TransactionProcessor.Reconciliation.DomainEvents.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Shared.DomainDrivenDesign" Version="2025.1.2" />
+		<PackageReference Include="Shared.DomainDrivenDesign" />
 	</ItemGroup>
 </Project>

--- a/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
+++ b/TransactionProcessor.Repository/TransactionProcessor.Repository.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FileProcessor.File.DomainEvents" Version="2026.2.2" />
-		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+		<PackageReference Include="FileProcessor.File.DomainEvents" />
+		<PackageReference Include="FileProcessor.FileImportLog.DomainEvents" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="OpenTelemetry.Api" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="Shared.EventStore" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" />
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
 
 	</ItemGroup>
 

--- a/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
+++ b/TransactionProcessor.Testing/TransactionProcessor.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -6,19 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" Version="2026.2.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="FileProcessor.FileImportLog.DomainEvents" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
+++ b/TransactionProcessor.Tests/TransactionProcessor.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net10.0</TargetFramework>
@@ -7,30 +7,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.ServiceModel.Federation" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="System.ServiceModel.NetTcp" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessor.sln
+++ b/TransactionProcessor.sln
@@ -46,6 +46,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Global

--- a/TransactionProcessor/Dockerfile
+++ b/TransactionProcessor/Dockerfile
@@ -9,6 +9,8 @@ COPY ["TransactionProcessor/NuGet.Config", "TransactionProcessor/"]
 COPY ["TransactionProcessor.DataTransferObjects/TransactionProcessor.DataTransferObjects.csproj", "TransactionProcessor.DataTransferObjects/"]
 COPY ["TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj", "TransactionProcessor.BusinessLogic/"]
 COPY ["TransactionProcessor.Models/TransactionProcessor.Models.csproj", "TransactionProcessor.Models/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TransactionProcessor/TransactionProcessor.csproj"
 COPY . .
 WORKDIR "/src/TransactionProcessor"

--- a/TransactionProcessor/Dockerfilewindows
+++ b/TransactionProcessor/Dockerfilewindows
@@ -10,6 +10,8 @@ COPY ["TransactionProcessor/NuGet.Config", "TransactionProcessor/"]
 COPY ["TransactionProcessor.DataTransferObjects/TransactionProcessor.DataTransferObjects.csproj", "TransactionProcessor.DataTransferObjects/"]
 COPY ["TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj", "TransactionProcessor.BusinessLogic/"]
 COPY ["TransactionProcessor.Models/TransactionProcessor.Models.csproj", "TransactionProcessor.Models/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TransactionProcessor/TransactionProcessor.csproj"
 COPY . .
 WORKDIR "/src/TransactionProcessor"

--- a/TransactionProcessor/TransactionProcessor.csproj
+++ b/TransactionProcessor/TransactionProcessor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,46 +10,46 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-	  <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-	  <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
-	  <PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="7.5.0" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
-	<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-	<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-	<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+	  <PackageReference Include="NuGet.Packaging" />
+	  <PackageReference Include="NuGet.Protocol" />
+	  <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+	  <PackageReference Include="OpenIddict.Validation.SystemNetHttp" />
+	  <PackageReference Include="ClientProxyBase" />
+	  <PackageReference Include="Lamar" />
+	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+	<PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+	<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" />
+	<PackageReference Include="AspNetCore.HealthChecks.Uris" />
+	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.3" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
-	  <PackageReference Include="prometheus-net" Version="8.2.1" />
-	  <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.6" />
-      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
-      <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
-	  <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-	  <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
-	  <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-	  <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
-	  <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
-	  <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
-	  <PackageReference Include="System.ServiceModel.Federation" Version="10.0.652802" />
-	  <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-	  <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
-	  <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-	  <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-	  <PackageReference Include="Sentry.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="OpenTelemetry.Api" />
+	  <PackageReference Include="prometheus-net" />
+	  <PackageReference Include="prometheus-net.AspNetCore" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.EventStore" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+      <PackageReference Include="Shared.Results.Web" />
+	  <PackageReference Include="Swashbuckle.AspNetCore" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+	  <PackageReference Include="System.ServiceModel.Federation" />
+	  <PackageReference Include="System.ServiceModel.Http" />
+	  <PackageReference Include="System.ServiceModel.NetTcp" />
+	  <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+	  <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+	  <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Centralize NuGet package versions with CPM

Migrated all NuGet package versioning to Directory.Packages.props using Central Package Management. Removed explicit Version attributes from .csproj files and updated Dockerfiles to include the new props file. Also performed minor code cleanups for consistency and modernization. This change ensures consistent dependency versions across the solution.

closes #1779 
closes #1786 