### PR TITLE
Improve estate retrieval error reporting and context usage

### DIFF
--- a/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessorSteps.cs
+++ b/TransactionProcessor.IntegrationTesting.Helpers/TransactionProcessorSteps.cs
@@ -579,15 +579,39 @@ public class TransactionProcessorSteps
             await Retry.For(async () => {
                     Result<List<EstateResponse>>? getEstatesResult = await this.TransactionProcessorClient
                         .GetEstates(accessToken, createEstateRequest.EstateId, CancellationToken.None).ConfigureAwait(false);
-                    getEstatesResult.IsSuccess.ShouldBeTrue();
+
                     List<EstateResponse>? estates = getEstatesResult.Data;
-                    estates.ShouldNotBeNull();
-                    estates.Count.ShouldBe(1);
-                    estate = estates.Single();
+                    try
+                    {
+                        getEstatesResult.IsSuccess.ShouldBeTrue();
+                        estates.ShouldNotBeNull();
+                        estates.Count.ShouldBe(1);
+                        estate = estates.Single();
+                        estate.EstateName.ShouldBe(createEstateRequest.EstateName);
+                        estate.EstateReference.ShouldNotBeNullOrWhiteSpace();
+                    }
+                    catch
+                    {
+                        StringBuilder snapshot = new StringBuilder();
+                        snapshot.Append($"estateId={createEstateRequest.EstateId}, expectedName={createEstateRequest.EstateName}, ");
+                        snapshot.Append($"isSuccess={getEstatesResult.IsSuccess}, ");
+                        snapshot.Append($"rows={(estates == null ? "null" : estates.Count.ToString())}");
+
+                        if (estates != null)
+                        {
+                            for (Int32 i = 0; i < estates.Count; i++)
+                            {
+                                EstateResponse currentEstate = estates[i];
+                                snapshot.Append($", row[{i}]={{id={currentEstate.EstateId}, name={currentEstate.EstateName}, reference={currentEstate.EstateReference ?? "<null>"}}}");
+                            }
+                        }
+
+                        Console.WriteLine($"[CreateEstate retry] {snapshot}");
+                        throw;
+                    }
                 },
                 retryFor: TimeSpan.FromSeconds(180)).ConfigureAwait(false);
 
-            estate.EstateName.ShouldBe(createEstateRequest.EstateName);
             results.Add(estate);
         }
 

--- a/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
+++ b/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
@@ -969,7 +969,8 @@ namespace TransactionProcessor.Repository {
         public async Task<Result<Models.Estate.Estate>> GetEstate(Guid estateId,
                                                            CancellationToken cancellationToken)
         {
-            EstateManagementContext context = await this.GetContext(estateId);
+            using ResolvedDbContext<EstateManagementContext>? resolvedContext = this.Resolver.Resolve(EstateManagementDatabaseName, estateId.ToString());
+            await using EstateManagementContext context = resolvedContext.Context;
 
             Database.Entities.Estate? estate = await context.Estates.SingleOrDefaultAsync(e => e.EstateId == estateId, cancellationToken);
 


### PR DESCRIPTION
Wrapped estate retrieval assertions in a try/catch block to provide detailed state snapshots on failure, aiding test debugging. Updated GetEstate to use ResolvedDbContext for proper context resolution and disposal.