### PR TITLE
Add GetMerchant method and MerchantReportingId support

### DIFF
--- a/TransactionProcessor.BusinessLogic.Tests/Manager/TransactionProcessorManagerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/Manager/TransactionProcessorManagerTests.cs
@@ -290,6 +290,9 @@ namespace TransactionProcessor.BusinessLogic.Tests.Manager
         {
             this.AggregateService.Setup(m => m.GetLatest<MerchantAggregate>(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.Aggregates.MerchantAggregateWithEverything(SettlementSchedule.Immediate)));
             this.AggregateService.Setup(o => o.GetLatest<OperatorAggregate>(It.IsAny<Guid>(), CancellationToken.None)).ReturnsAsync(Result.Success(TestData.Aggregates.CreatedOperatorAggregate()));
+            this.TransactionProcessorReadModelRepository
+                .Setup(r => r.GetMerchant(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success(TestData.MerchantModelWithAddressesContactsDevicesAndOperatorsAndContracts()));
 
             Merchant expectedModel = TestData.MerchantModelWithAddressesContactsDevicesAndOperatorsAndContracts();
 

--- a/TransactionProcessor.BusinessLogic.Tests/RequestHandler/MerchantRequestHandlerTests.cs
+++ b/TransactionProcessor.BusinessLogic.Tests/RequestHandler/MerchantRequestHandlerTests.cs
@@ -1,0 +1,60 @@
+using Moq;
+using Shared.EventStore.EventStore;
+using Shared.Serialisation;
+using Shouldly;
+using SimpleResults;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TransactionProcessor.BusinessLogic.Manager;
+using TransactionProcessor.BusinessLogic.RequestHandlers;
+using TransactionProcessor.BusinessLogic.Requests;
+using TransactionProcessor.BusinessLogic.Services;
+using TransactionProcessor.ProjectionEngine.Repository;
+using TransactionProcessor.ProjectionEngine.State;
+using TransactionProcessor.Testing;
+using Xunit;
+
+using MerchantModel = TransactionProcessor.Models.Merchant.Merchant;
+
+namespace TransactionProcessor.BusinessLogic.Tests.RequestHandler;
+
+public class MerchantRequestHandlerTests
+{
+    public MerchantRequestHandlerTests()
+    {
+        StringSerialiser.Initialise(new SystemTextJsonSerializer(new JsonSerializerOptions()));
+    }
+
+    [Fact]
+    public async Task MerchantRequestHandler_GetMerchantQuery_ReturnsMerchantReportingId()
+    {
+        Mock<IProjectionStateRepository<MerchantBalanceState>> merchantBalanceStateRepository = new();
+        Mock<IEventStoreContext> eventStoreContext = new();
+        Mock<ITransactionProcessorReadRepository> transactionProcessorReadRepository = new();
+        Mock<IMerchantDomainService> merchantDomainService = new();
+        Mock<ITransactionProcessorManager> manager = new();
+        MerchantRequestHandler handler = new(
+            merchantBalanceStateRepository.Object,
+            eventStoreContext.Object,
+            transactionProcessorReadRepository.Object,
+            merchantDomainService.Object,
+            manager.Object);
+
+        MerchantModel expectedMerchant = TestData.MerchantModelWithAddressesContactsDevicesAndOperatorsAndContracts();
+        expectedMerchant.MerchantReportingId = TestData.MerchantReportingId;
+
+        manager
+            .Setup(m => m.GetMerchant(TestData.EstateId, TestData.MerchantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(expectedMerchant));
+
+        MerchantQueries.GetMerchantQuery query = TestData.Queries.GetMerchantQuery;
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Data.ShouldNotBeNull();
+        result.Data.MerchantReportingId.ShouldBe(TestData.MerchantReportingId);
+        manager.Verify(m => m.GetMerchant(TestData.EstateId, TestData.MerchantId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TransactionProcessor.BusinessLogic/Manager/TransactionProcessorManager.cs
+++ b/TransactionProcessor.BusinessLogic/Manager/TransactionProcessorManager.cs
@@ -152,6 +152,13 @@ namespace TransactionProcessor.BusinessLogic.Manager
                 }
             }
 
+            Result<Merchant> merchantReadModelResult = await this.TransactionProcessorReadModelRepository.GetMerchant(estateId, merchantId, cancellationToken);
+            if (merchantReadModelResult.IsFailed) {
+                return ResultHelpers.CreateFailure(merchantReadModelResult);
+            }
+
+            merchantModel.MerchantReportingId = merchantReadModelResult.Data.MerchantReportingId;
+
             return Result.Success(merchantModel);
         }
 

--- a/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
+++ b/TransactionProcessor.Repository/ITransactionProcessorReadModelRepository.cs
@@ -278,6 +278,9 @@ namespace TransactionProcessor.Repository {
         Task<Result<List<MerchantModel>>> GetMerchants(Guid estateId,
                                                         CancellationToken cancellationToken);
 
+        Task<Result<MerchantModel>> GetMerchant(Guid estateId, Guid merchantId,
+                                                CancellationToken cancellationToken);
+
         Task<Result<MerchantScheduleModel>> GetMerchantSchedule(Guid estateId,
                                                                 Guid merchantId,
                                                                 Int32 year,
@@ -890,6 +893,32 @@ namespace TransactionProcessor.Repository {
             }
 
             return Result.Success(models);
+        }
+
+        public async Task<Result<MerchantModel>> GetMerchant(Guid estateId,
+                                                             Guid merchantId,
+                                                             CancellationToken cancellationToken) {
+            using ResolvedDbContext<EstateManagementContext>? resolvedContext = this.Resolver.Resolve(EstateManagementDatabaseName, estateId.ToString());
+            await using EstateManagementContext context = resolvedContext.Context;
+
+            Merchant? merchant = await (from m in context.Merchants where m.EstateId == estateId && m.MerchantId == merchantId select m).SingleOrDefaultAsync(cancellationToken);
+            List<MerchantAddress> merchantAddresses = await (from a in context.MerchantAddresses where a.MerchantId == merchantId select a).ToListAsync(cancellationToken);
+            List<MerchantContact> merchantContacts = await (from c in context.MerchantContacts where c.MerchantId == merchantId select c).ToListAsync(cancellationToken);
+            List<MerchantOperator> merchantOperators = await (from o in context.MerchantOperators where o.MerchantId == merchantId select o).ToListAsync(cancellationToken);
+            List<MerchantSecurityUser> merchantSecurityUsers = await (from u in context.MerchantSecurityUsers where u.MerchantId == merchantId select u).ToListAsync(cancellationToken);
+            List<MerchantDevice> merchantDevices = await (from d in context.MerchantDevices where d.MerchantId == merchantId select d).ToListAsync(cancellationToken);
+            List<MerchantSchedule> merchantSchedules = await (from s in context.MerchantSchedules where s.MerchantId == merchantId select s).ToListAsync(cancellationToken);
+            List<MerchantScheduleMonth> merchantScheduleMonths = await (from sm in context.MerchantScheduleMonths
+                                                                        where merchantSchedules.Select(s => s.MerchantScheduleId).Contains(sm.MerchantScheduleId)
+                                                                        select sm).ToListAsync(cancellationToken);
+
+            if (merchant == null) {
+                return Result.NotFound($"No merchant found for estate {estateId} and merchant {merchantId}");
+            }
+
+            MerchantModel model = ModelFactory.ConvertFrom(estateId, merchant, merchantAddresses, merchantContacts, merchantOperators, merchantDevices, merchantSecurityUsers, (Schedules: merchantSchedules, Months: merchantScheduleMonths));
+
+            return Result.Success(model);
         }
 
         public async Task<Result<MerchantScheduleModel>> GetMerchantSchedule(Guid estateId,


### PR DESCRIPTION
Introduce GetMerchant to ITransactionProcessorReadModelRepository and its implementation for retrieving a merchant and related entities by estate and merchant ID. Update TransactionProcessorManager to set MerchantReportingId on the merchant model. Add MerchantRequestHandlerTests to verify MerchantReportingId retrieval.