### PR TITLE
Remove unused Syncfusion package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,7 +75,6 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
-    <PackageVersion Include="Syncfusion.HtmlToPdfConverter.Net.Windows" Version="33.2.12" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />

--- a/TransactionProcessor.BusinessLogic/Services/StatementBuilder.cs
+++ b/TransactionProcessor.BusinessLogic/Services/StatementBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Html;
 using Shared.General;
-using Syncfusion.HtmlConverter;
-using Syncfusion.Pdf;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
+++ b/TransactionProcessor.BusinessLogic/TransactionProcessor.BusinessLogic.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Shared.DomainDrivenDesign" />
     <PackageReference Include="Shared.EventStore" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Syncfusion.HtmlToPdfConverter.Net.Windows" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="System.ServiceModel.Duplex" />

--- a/TransactionProcessor.IntegrationTests/Common/DockerHelper.cs
+++ b/TransactionProcessor.IntegrationTests/Common/DockerHelper.cs
@@ -1,5 +1,4 @@
 ﻿using DotNet.Testcontainers.Builders;
-using Syncfusion.Pdf.Xmp;
 using System.IO;
 using TestHosts.Clients;
 using TransactionProcessor.Database.Contexts;


### PR DESCRIPTION
Removed the unused Syncfusion.HtmlToPdfConverter package from BusinessLogic and stripped stale Syncfusion imports from the API and integration tests. Verified with dotnet build on the API project and the integration test project.